### PR TITLE
basic refactoring to reflect issue #13 point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tck/bin/
 .project
 build/
 .classpath
+.idea
+*.iml

--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -45,7 +45,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  *
  */
-public interface Config {
+public interface Config extends AutoCloseable {
     /**
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
@@ -87,5 +87,11 @@ public interface Config {
      * @return all currently registered {@link ConfigSource configsources}
      */
     Iterable<ConfigSource> getConfigSources();
+
+    /**
+     * Let the implementation release any resource it can need and then the config is no more usable.
+     */
+    @Override
+    void close();
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigProviderResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigProviderResolver.java
@@ -23,11 +23,11 @@ import java.security.PrivilegedAction;
 import java.util.ServiceLoader;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider.ConfigBuilder;
 
 /**
- * This class is not intended to be used by end-users but for
- * portable container integration purpose only!
+ * Way to access automatically created configurations, this can be seems as a configuration instances manager.
+ *
+ * Note: it is ClassLoader based to lookup the right Config instance so setConfig() and lookup() need to match.
  *
  * Service provider for ConfigProviderResolver. The implementation registers
  * itself via {@link java.util.ServiceLoader} mechanism.
@@ -43,27 +43,72 @@ public abstract class ConfigProviderResolver {
     private static volatile ConfigProviderResolver instance = null;
 
     /**
-     * @see org.eclipse.microprofile.config.ConfigProvider#getConfig()
+     * Provide a {@link Config} based on all {@link ConfigSource ConfigSources} of the
+     * current Thread Context ClassLoader (TCCL)
+     * The {@link Config} will be stored for future retrieval.
+     * <p>
+     * There is exactly a single Config instance per ClassLoader
+     * </p>
+     *
+     * If no instance is provided it will call
+     * <code>
+     *     ConfigProvider.newBuilder().addDefaultSources().build();
+     * </code>
+     * to get a new one.
+     */
+    public static Config lookup() {
+        return instance().getConfig();
+    }
+
+
+    /**
+     * Provide a {@link Config} based on all {@link ConfigSource ConfigSources} of the
+     * specified ClassLoader
+     *
+     * <p>
+     * There is exactly a single Config instance per ClassLoader
+     * </p>
+     *
+     * If no instance is provided it will call
+     * <code>
+     *     ConfigProvider.newBuilder().addDefaultSources().build();
+     * </code>
+     * to get a new one.
+     */
+    public static Config lookup(ClassLoader loader) {
+        return instance().getConfig(loader);
+    }
+
+    /**
+     * @see ConfigProviderResolver#lookup()
      */
     public abstract Config getConfig();
 
     /**
-     * @see org.eclipse.microprofile.config.ConfigProvider#getConfig(ClassLoader)
+     * @see ConfigProviderResolver#lookup(ClassLoader)
      */
     public abstract Config getConfig(ClassLoader loader);
 
     /**
-     * @see org.eclipse.microprofile.config.ConfigProvider#getBuilder()
-     */
-    public abstract ConfigBuilder getBuilder();
-
-    /**
-     * @see org.eclipse.microprofile.config.ConfigProvider#setConfig(Config, ClassLoader)
+     * Register a given {@link Config} within the Application (or Module) identified by the given ClassLoader.
+     * If the ClassLoader is {@code null} then the current Application will be used.
+     *
+     * @param config
+     *          which should get registered
+     * @param classLoader
+     *          which identifies the Application or Module the given Config should get associated with.
+     *
+     * @throws IllegalStateException
+     *          if there is already a Config registered within the Application.
+     *          A user could explicitly use {@link #releaseConfig(Config)} for this case.
      */
     public abstract void setConfig(Config config, ClassLoader classLoader);
 
     /**
-     * @see org.eclipse.microprofile.config.ConfigProvider#releaseConfig(Config)
+     * A {@link Config} normally gets released if the Application it is associated with gets destroyed.
+     * Invoke this method if you like to destroy the Config prematurely.
+     *
+     * If the given Config is associated within an Application then it will be unregistered.
      */
     public abstract void releaseConfig(Config config);
 
@@ -77,16 +122,8 @@ public abstract class ConfigProviderResolver {
                 if (instance != null) {
                     return instance;
                 }
-                
-                ClassLoader cl = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
-                    @Override
-                    public ClassLoader run()  {
-                        return Thread.currentThread().getContextClassLoader();
-                    }                                  
-                });
-                if (cl == null) {
-                    cl = ConfigProviderResolver.class.getClassLoader();
-                }
+
+                ClassLoader cl = getClassLoader();
 
                 ConfigProviderResolver newInstance = loadSpi(cl);
 
@@ -101,10 +138,26 @@ public abstract class ConfigProviderResolver {
         return instance;
     }
 
+    private static ClassLoader getClassLoader() {
+        ClassLoader cl = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            @Override
+            public ClassLoader run()  {
+                return Thread.currentThread().getContextClassLoader();
+            }
+        });
+        if (cl == null) {
+            cl = ConfigProviderResolver.class.getClassLoader();
+        }
+        return cl;
+    }
+
     private static ConfigProviderResolver loadSpi(ClassLoader cl) {
         if (cl == null) {
             return null;
         }
+
+        // todo: application provided impl should override parent instead no, otherwise no point to have this logic and
+        //       just use CPR.class.getClassLoader()?
 
         // start from the root CL and go back down to the TCCL
         ConfigProviderResolver instance = loadSpi(cl.getParent());
@@ -133,6 +186,9 @@ public abstract class ConfigProviderResolver {
      *            set the instance.
      */
     public static void setInstance(ConfigProviderResolver resolver) {
+        if (instance != null) {
+            throw new IllegalStateException("Instance already set");
+        }
         instance = resolver;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
@@ -20,8 +20,9 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,11 +31,16 @@ import org.testng.annotations.Test;
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  */
 public class ConfigProviderTest {
+    @Test
+    public void testCustomUnmanagedConfigInstance() {
+        Config c = ConfigProvider.newBuilder().build();
+        Assert.assertNotNull(c);
+    }
 
     @Test
     public void testEnvironmentConfigSource() {
         Map<String, String> env = System.getenv();
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
         for (Map.Entry<String, String> envEntry : env.entrySet()) {
             Assert.assertEquals(envEntry.getValue(), config.getString(envEntry.getKey()).get());
         }
@@ -43,7 +49,7 @@ public class ConfigProviderTest {
     @Test
     public void testPropertyConfigSource() {
         Properties properties = System.getProperties();
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
 
         for (Map.Entry<Object, Object> propEntry : properties.entrySet()) {
             Assert.assertEquals(propEntry.getValue(), config.getString((String) propEntry.getKey()).get());
@@ -52,7 +58,7 @@ public class ConfigProviderTest {
 
     @Test
     public void testDynamicValueInPropertyConfigSource() {
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
         String configKey = "tck.config.test.systemproperty.dynamic.value";
         String configValue = "myDynamicValue;";
 
@@ -62,13 +68,13 @@ public class ConfigProviderTest {
 
     @Test
     public void testJavaConfigPropertyFilesConfigSource() {
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
         Assert.assertEquals(config.getString("tck.config.test.javaconfig.properties.key1").get(), "VALue1");
     }
 
     @Test
     public void testNonExistingConfigKey() {
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
         Assert.assertNull(config.getString("tck.config.test.keydoesnotexist").get());
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConverterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConverterTest.java
@@ -17,7 +17,7 @@
 package org.eclipse.microprofile.config.tck;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,7 +28,7 @@ public class ConverterTest {
 
     @Test
     public void testIntegerConverter() {
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
         Integer value = config.getValue("tck.config.test.javaconfig.converter.integervalue", Integer.class).get();
         Assert.assertEquals(value, Integer.valueOf(1234));
 
@@ -36,7 +36,7 @@ public class ConverterTest {
 
     @Test
     public void testFloatConverter() {
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
         Float value = config.getValue("tck.config.test.javaconfig.converter.floatvalue", Float.class).get();
         Assert.assertEquals(value, Float.valueOf(12.34f));
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/CustomConfigSourceTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/CustomConfigSourceTest.java
@@ -17,7 +17,7 @@
 package org.eclipse.microprofile.config.tck;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,7 +28,7 @@ public class CustomConfigSourceTest {
 
     @Test
     public void testConfigSourceProvider() {
-        Config config = ConfigProvider.getConfig();
+        Config config = ConfigProviderResolver.lookup();
 
         Assert.assertEquals(config.getString("tck.config.test.customDbConfig.key1").get(), "valueFromDb1");
     }


### PR DESCRIPTION
Here are the changes:

1. Config should have a close method which is unlinked to the contextuality - think unmanaged case. It can belong to provider too but in term of user API it looks more friendly this way IMHO
2. ConfigProviderResolver owns the "mapping" between a classloader and a config and reflect a light Map API for that with static utility for global lookups (personally i would have dropped it from the spec and wait to see if users don't have enough of common IoCs but seems a blocker for Emily and Mark)
3. Keep ConfigProvider as the API link between the API/user code and implementation (to load the builder) *only*

I'm not yet a fan of ConfigProviderResolver and wonder if we shouldn't replace the ClassLoader by a Key which would be an interface but let's keep it for next thought round, there are already enough there for now ;).

