### PR TITLE
Updated Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@
 
 ## Status
 
-MicroProfile Config proposal!
+MicroProfile Config Framework
 
 == Rational
 
@@ -34,14 +34,17 @@ The changed values should be fed into the client without the need for restarting
 This requirement is particularly important for micro services running in a cloud environment.
 The MicroProfile Config approach allows to pick up configured values immediately after they got changed.
 
-== Implementaions
+== Related projects
 
 There are a number of Config supporting projects, such as:
 
 * Netflix Archaius (https://github.com/Netflix/archaius)
 * DeltaSpike Config (http://deltaspike.apache.org/documentation/configuration.html)
-* Extracted parts of DeltaSpike Config (https://github.com/struberg/javaConfig/)
 * Apache Tamaya (http://tamaya.incubator.apache.org/)
+
+== Implementations
+
+* Implementation of MicroProfile Config (https://github.com/struberg/javaConfig/)
 
 == Design
 

--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@
 
 ## Status
 
-MicroProfile Config Framework
+MicroProfile Config Specification
 
 == Rational
 


### PR DESCRIPTION
The Readme File still said "proposal" it should be something else, called it "Framework" since there is a little more than the API here
Fixed at least one typo in the "implementations" headline. Plus separating implementations from "related efforts". The link originally called "forked DeltaSpike" now points to an implementation of the API here.

Signed-off-by: Werner Keil <werner.keil@gmx.net>