### PR TITLE
Renamed artifact, removed common annotations dep

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,20 +24,13 @@
         <version>0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.eclipse.microprofile.apis</groupId>
-    <artifactId>microprofile-config_1.0_api</artifactId>
+    <groupId>org.eclipse.microprofile.api</groupId>
+    <artifactId>microprofile-config-api</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>MicroProfile Config API</name>
 
 
     <dependencies>
-        <dependency>
-            <!-- actually only referenced in JavaDoc -->
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-annotation_1.2_spec</artifactId>
-            <version>1.0</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
@@ -56,7 +56,7 @@ package org.eclipse.microprofile.config.spi;
  * <code>META-INF/services/org.eclipse.microprofile.config.spi.Converter</code><br>
  * which contains the fully qualified {@code Converter} implementation class name as content.
  *
- * <p>A Converter can specify a {@link javax.annotation.Priority}.
+ * <p>A Converter can specify a {@code javax.annotation.Priority}.
  * If no priority is explicitly assigned, the value of 100 is assumed.
  * If multiple Converters are registered for the same type, the one with the highest priority will be used.
  *


### PR DESCRIPTION
Removed the unnecessary dependency on common annotations, which is only used in Javadoc