### PR TITLE
#89 Added test for serializability of injected config

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
@@ -19,6 +19,7 @@
  */
 package org.eclipse.microprofile.config.tck;
 
+import java.io.*;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
@@ -28,6 +29,8 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.tck.base.AbstractTest;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -128,6 +131,23 @@ public class ConfigProviderTest extends Arquillian {
             prevOrdinal = configSource.getOrdinal();
         }
 
+    }
+    
+    @Test
+    public void testInjectedConfigSerializable() {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(byteArrayOutputStream)) {
+            out.writeObject(config);
+        } catch (IOException ex) {
+            Assert.fail("Injected config should be serializable, but could not serialize it", ex);
+        }
+        Object readObject = null;
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))) {
+            readObject = in.readObject();
+        } catch (IOException | ClassNotFoundException ex) {
+            Assert.fail("Injected config should be serializable, but could not deserialize a previously serialized instance", ex);
+        }
+        MatcherAssert.assertThat("Deserialized object", readObject, CoreMatchers.instanceOf(Config.class));
     }
 
 }


### PR DESCRIPTION
Part of issue #89.
The test just checks whether it's possible to serialize, deserialize and whether the deserialized object is again a `Config` instance. 

It doesn't check whether it gives any config values - the config values should ideally not be serialized, but retrieved from the runtime environment (especially if it moved to another JVM)

Mark's sample implementation already passes the test. 