### PR TITLE
Fix warnings when building the spec.

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -46,7 +46,7 @@ com.acme.myproject.someserver.port = 9085
 com.acme.myproject.someserver.active = true
 com.acme.other.stuff.name = Karl
 com.acme.myproject.notify.onerror=karl@mycompany,sue@mcompany
-some.library.own.config=somem value
+some.library.own.config=some value
 ----
 
 

--- a/spec/src/main/asciidoc/microprofile-config-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-config-spec.asciidoc
@@ -36,7 +36,7 @@ endif::[]
 
 include::license-alv2.asciidoc[]
 
-=== Microprofile Config
+== Microprofile Config
 
 
 include::architecture.asciidoc[]


### PR DESCRIPTION
This fixes #156.

Signed-off-by: John D. Ament <john.d.ament@gmail.com>