### PR TITLE
Change javax.config.spi to org.eclipse.microprofile.config.spi

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
@@ -48,7 +48,7 @@ import java.util.Map;
  * <p>Custom ConfigSource will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
  * providing a file
  * <pre>
- *     META-INF/services/javax.config.spi.ConfigSource
+ *     META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
  * </pre>
  * which contains the fully qualified {@code ConfigSource} implementation class name as content.
  *

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSourceProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSourceProvider.java
@@ -40,7 +40,7 @@ package org.eclipse.microprofile.config.spi;
  *
  * <p>A ConfigSourceProvider will get picked up via the
  * {@link java.util.ServiceLoader} mechanism and can be registered by providing a
- * {@code META-INF/services/javax.config.spi.ConfigSourceProvider} file which contains
+ * {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider} file which contains
  * the fully qualified classname of the custom ConfigSourceProvider.
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>


### PR DESCRIPTION
Update the javax.config.spi prefix referenced in the javadoc talking about ServiceLoader extension mechanism to org.eclipse.microprofile.config.spi