### PR TITLE
listing site documentation on microprofile.io

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -1,6 +1,5 @@
 %YAML 1.2
 ---
-friendly_name: "My custom name"
 documentation:
   - title: Configuration for Microprofile
     file: spec/src/main/asciidoc/microprofile-config-spec.asciidoc

--- a/site.yaml
+++ b/site.yaml
@@ -1,5 +1,6 @@
 %YAML 1.2
 ---
+friendly_name: "My custom name"
 documentation:
   - title: Configuration for Microprofile
     file: spec/src/main/asciidoc/microprofile-config-spec.asciidoc

--- a/site.yaml
+++ b/site.yaml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+documentation:
+  - title: Configuration for Microprofile
+    file: spec/src/main/asciidoc/microprofile-config-spec.asciidoc
+
+  - title: Architecture
+    file: spec/src/main/asciidoc/architecture.asciidoc
+
+  - title: Configuration Usage Examples
+    file: spec/src/main/asciidoc/configexamples.asciidoc
+
+  - title: Accessing or Creating a certain Configuration
+    file: spec/src/main/asciidoc/configprovider.asciidoc
+
+  - title: ConfigSources
+    file: spec/src/main/asciidoc/configsources.asciidoc
+
+  - title: Converter
+    file: spec/src/main/asciidoc/converters.asciidoc
+
+  - title: License
+    file: spec/src/main/asciidoc/license-alv2.asciidoc


### PR DESCRIPTION
This file is used by the microprofile.io website in order for the listed projects to have more control on what is published on http://microprofile.io/projects

The entry in this file will list the project documentation in a list like the one in the screenshot.

![screen shot 2017-06-15 at 2 57 49 pm](https://user-images.githubusercontent.com/1918442/27197523-7bab8514-51dc-11e7-944d-3178339b3f82.png)

