### PR TITLE
Clarify that primitive converts should be built in by default.

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
@@ -34,12 +34,12 @@ package org.eclipse.microprofile.config.spi;
  **
  * <p>Converters for the following types are provided by default:
  * <ul>
- *     <li>{@code Boolean}, values for {@code true}: (case insensitive)
+ *     <li>{@code boolean} and {@code Boolean}, values for {@code true}: (case insensitive)
  *     &quot;true&quot;, &quot;yes&quot;, &quot;Y&quot;, &quot;on&quot;, &quot;1&quot;</li>
- *     <li>{@code Integer}</li>
- *     <li>{@code Long}</li>
- *     <li>{@code Float}, a dot '.' is used to separate the fractional digits</li>
- *     <li>{@code Double}, a dot '.' is used to separate the fractional digits</li>
+ *     <li>{@code int} and {@code Integer}</li>
+ *     <li>{@code long} and {@code Long}</li>
+ *     <li>{@code float} and {@code Float}, a dot '.' is used to separate the fractional digits</li>
+ *     <li>{@code double} and {@code Double}, a dot '.' is used to separate the fractional digits</li>
  *     <li>{@code java.time.Duration} as defined in {@link java.time.Duration#parse(CharSequence)}</li>
  *     <li>{@code java.time.LocalDateTime} as defined in {@link java.time.LocalDateTime#parse(CharSequence)}</li>
  *     <li>{@code java.time.LocalDate} as defined in {@link java.time.LocalDate#parse(CharSequence)}</li>

--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -29,12 +29,12 @@ This happens by providing `Converter` s in the `Config`.
 
 The following `Converter` s are provided by Microprofile-Config by default:
 
-* `Boolean` , values for `true` (case insensitive) "true", "1", "YES", "Y" "ON".
+* `boolean` and `Boolean` , values for `true` (case insensitive) "true", "1", "YES", "Y" "ON".
   Any other value will be interpreted as `false`
-* `Integer`
-* `Long`
-* `Float` , a dot '.' is used to separate the fractional digits
-* `Double` , a dot '.' is used to separate the fractional digits
+* `int` and `Integer`
+* `long` and `Long`
+* `float` and `Float` , a dot '.' is used to separate the fractional digits
+* `double` and `Double` , a dot '.' is used to separate the fractional digits
 * `Duration`
 * `LocalTime`
 * `LocalDate`

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPlainInjectionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPlainInjectionTest.java
@@ -67,11 +67,18 @@ public class CDIPlainInjectionTest extends Arquillian {
         SimpleValuesBean bean = getBeanOfType(SimpleValuesBean.class);
 
         assertThat(bean.stringProperty, is(equalTo("text")));
-        assertThat(bean.boolProperty, is(true));
+        assertThat(bean.booleanProperty, is(true));
         assertThat(bean.intProperty, is(equalTo(5)));
         assertThat(bean.longProperty, is(equalTo(10L)));
         assertThat(bean.floatProperty, is(floatCloseTo(10.5f, 0.1f)));
         assertThat(bean.doubleProperty, is(closeTo(11.5, 0.1)));
+
+        assertThat(bean.booleanObjProperty, is(true));
+        assertThat(bean.integerProperty, is(equalTo(5)));
+        assertThat(bean.longObjProperty, is(equalTo(10L)));
+        assertThat(bean.floatObjProperty, is(floatCloseTo(10.5f, 0.1f)));
+        assertThat(bean.doubleObjProperty, is(closeTo(11.5, 0.1)));
+
         assertThat(bean.doublePropertyWithDefaultValue, is(closeTo(3.1415, 0.1)));
     }
 
@@ -119,23 +126,43 @@ public class CDIPlainInjectionTest extends Arquillian {
 
         @Inject
         @ConfigProperty(name="my.boolean.property")
-        private Boolean boolProperty;
+        private Boolean booleanObjProperty;
+
+        @Inject
+        @ConfigProperty(name="my.boolean.property")
+        private boolean booleanProperty;
 
         @Inject
         @ConfigProperty(name="my.int.property")
-        private Integer intProperty;
+        private Integer integerProperty;
+
+        @Inject
+        @ConfigProperty(name="my.int.property")
+        private int intProperty;
 
         @Inject
         @ConfigProperty(name="my.long.property")
-        private Long longProperty;
+        private Long longObjProperty;
+
+        @Inject
+        @ConfigProperty(name="my.long.property")
+        private long longProperty;
 
         @Inject
         @ConfigProperty(name="my.float.property")
-        private Float floatProperty;
+        private Float floatObjProperty;
+
+        @Inject
+        @ConfigProperty(name="my.float.property")
+        private float floatProperty;
 
         @Inject
         @ConfigProperty(name="my.double.property")
-        private Double doubleProperty;
+        private Double doubleObjProperty;
+
+        @Inject
+        @ConfigProperty(name="my.double.property")
+        private double doubleProperty;
 
         // the property is not configured in any ConfigSource but its defaultValue will
         // be used to set the field.

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConverterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConverterTest.java
@@ -89,6 +89,12 @@ public class ConverterTest extends Arquillian {
         Assert.assertEquals(value, Integer.valueOf(1234));
     }
 
+    @Test
+    public void testInt() {
+        int value = config.getValue("tck.config.test.javaconfig.converter.integervalue", int.class);
+        Assert.assertEquals(value, 1234);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testInteger_Broken() {
         Integer value = config.getValue("tck.config.test.javaconfig.converter.integervalue.broken", Integer.class);
@@ -100,26 +106,44 @@ public class ConverterTest extends Arquillian {
         Assert.assertEquals(value, Long.valueOf(1234567890));
     }
 
+    @Test
+    public void testlong() {
+        long primitiveValue = config.getValue("tck.config.test.javaconfig.converter.longvalue", long.class);
+        Assert.assertEquals(primitiveValue, 1234567890L);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testLong_Broken() {
-        Long value = config.getValue("tck.config.test.javaconfig.converter.longvalue.broken", Long.class);
+        config.getValue("tck.config.test.javaconfig.converter.longvalue.broken", Long.class);
     }
 
     @Test
     public void testFloat() {
         Float value = config.getValue("tck.config.test.javaconfig.converter.floatvalue", Float.class);
-        Assert.assertEquals(value, Float.valueOf(12.34f));
+        Assert.assertEquals(value, 12.34f);
+    }
+
+    @Test
+    public void testfloat() {
+        float value = config.getValue("tck.config.test.javaconfig.converter.floatvalue", float.class);
+        Assert.assertEquals(value, 12.34f);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testFloat_Broken() {
-        Float value = config.getValue("tck.config.test.javaconfig.converter.floatvalue.broken", Float.class);
+        config.getValue("tck.config.test.javaconfig.converter.floatvalue.broken", Float.class);
     }
 
     @Test
     public void testDouble() {
         Double value = config.getValue("tck.config.test.javaconfig.converter.doublevalue", Double.class);
-        Assert.assertEquals(value, Double.valueOf(12.34d));
+        Assert.assertEquals(value, 12.34d);
+    }
+
+    @Test
+    public void testdouble() {
+        double value = config.getValue("tck.config.test.javaconfig.converter.doublevalue", double.class);
+        Assert.assertEquals(value,12.34d);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -208,6 +232,7 @@ public class ConverterTest extends Arquillian {
     @Test
     public void testBoolean() {
         Assert.assertTrue(config.getValue("tck.config.test.javaconfig.configvalue.boolean.true", Boolean.class));
+        Assert.assertTrue(config.getValue("tck.config.test.javaconfig.configvalue.boolean.true", boolean.class));
         Assert.assertTrue(config.getValue("tck.config.test.javaconfig.configvalue.boolean.true_uppercase", Boolean.class));
         Assert.assertTrue(config.getValue("tck.config.test.javaconfig.configvalue.boolean.true_mixedcase", Boolean.class));
         Assert.assertFalse(config.getValue("tck.config.test.javaconfig.configvalue.boolean.false", Boolean.class));
@@ -229,6 +254,7 @@ public class ConverterTest extends Arquillian {
         Assert.assertTrue(config.getValue("tck.config.test.javaconfig.configvalue.boolean.on_uppercase", Boolean.class));
         Assert.assertTrue(config.getValue("tck.config.test.javaconfig.configvalue.boolean.on_mixedcase", Boolean.class));
         Assert.assertFalse(config.getValue("tck.config.test.javaconfig.configvalue.boolean.off", Boolean.class));
+        Assert.assertFalse(config.getValue("tck.config.test.javaconfig.configvalue.boolean.off", boolean.class));
     }
 
     @Test


### PR DESCRIPTION
This closes #204

Signed-off-by: John D. Ament <john.d.ament@gmail.com>