### PR TITLE
expand the variable checking and support a release.conf file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ test-output
 *.iml
 *.iwl
 *.ipr
+# Ignore a release.conf for perform_release/* script usage
+release.conf


### PR DESCRIPTION
Signed-off-by: Scott Stark <starksm64@gmail.com>

Hello, while testing this script for a jwt release, I made some change to report on exactly what variable are not defined, and added support to pull these in from a release.conf file that is ignored. Example output when there are missing variable definitions:

```
[microprofile-config 1051]$ cat release.conf 
#RELEASE_VERSION=1.0-RC1
#DEV_VERSION=1.0-SNAPSHOT
GIT_USER='Scott M Stark'
#GIT_EMAIL='starksm64@gmail.com'
[microprofile-config 1052]$ bash perform_release/prepare_release.sh 
RELEASE_VERSION is not defined
DEV_VERSION is not defined
GIT_EMAIL is not defined
ERROR: the following required variables are not defined: RELEASE_VERSION DEV_VERSION GIT_EMAIL
```

I don't know why the last three changes in the the perform_release/prepare_release.sh are there as I did not change them, could be some subtle white space issue I can't see.
