### PR TITLE
Typo: The adjective "rational" should be the noun "rationale".

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@
 
 MicroProfile Config Feature
 
-== Rational
+== Rationale
 
 The majority of applications need to be configured based on a running environment.
 It must be possible to modify configuration data from outside an application so that the application itself does not need to be repackaged.


### PR DESCRIPTION
See, e.g., http://grammarist.com/usage/rational-or-rationale/