### PR TITLE
Spec module to add pdf and html artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,9 +174,20 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>1.6</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.eclipse.microprofile.maven</groupId>
+                <artifactId>microprofile-maven-build-extension</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
             <name>Project Repository - Releases</name>
             <url>https://repo.eclipse.org/content/groups/cbi/</url>
         </pluginRepository>
+        <pluginRepository>
+            <id>microprofile.repo.eclipse.org</id>
+            <name>Microprofile Project Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/groups/microprofile/</url>
+        </pluginRepository>
     </pluginRepositories>
 
     <build>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -25,13 +25,12 @@
 
     <groupId>org.eclipse.microprofile.config</groupId>
     <artifactId>microprofile-config-spec</artifactId>
-    <packaging>pdf</packaging>
+    <packaging>pom</packaging>
     <name>MicroProfile Config Specification</name>
 
     <properties>
         <asciidoctor-maven.version>1.5.5</asciidoctor-maven.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
-        <asciidoctor.skip>false</asciidoctor.skip>
         <license>Apache License v 2.0</license>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
@@ -41,12 +40,6 @@
         <finalName>${project.artifactId}</finalName>
         <defaultGoal>clean package</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>org.eclipse.microprofile.maven</groupId>
-                <artifactId>microprofile-maven-build-extension</artifactId>
-                <version>1.0</version>
-                <extensions>true</extensions>
-            </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -89,8 +82,44 @@
                         <license>Apache License v2.0</license>
                     </attributes>
                     <outputDirectory>${project.build.directory}</outputDirectory>
-                    <skip>${asciidoctor.skip}</skip>
+                    <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-pdf-artifact</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/${project.build.finalName}.pdf</file>
+                                    <type>pdf</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>attach-html-artifact</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.build.directory}/${project.build.finalName}.html</file>
+                                    <type>html</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>            
             </plugin>
         </plugins>
     </build>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -25,20 +25,28 @@
 
     <groupId>org.eclipse.microprofile.config</groupId>
     <artifactId>microprofile-config-spec</artifactId>
-    <packaging>pom</packaging>
+    <packaging>pdf</packaging>
     <name>MicroProfile Config Specification</name>
 
     <properties>
         <asciidoctor-maven.version>1.5.5</asciidoctor-maven.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
+        <asciidoctor.skip>false</asciidoctor.skip>
         <license>Apache License v 2.0</license>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
     </properties>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <defaultGoal>clean package</defaultGoal>
         <plugins>
+            <plugin>
+                <groupId>org.eclipse.microprofile.maven</groupId>
+                <artifactId>microprofile-maven-build-extension</artifactId>
+                <version>1.0</version>
+                <extensions>true</extensions>
+            </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -59,6 +67,7 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
+                            <outputFile>${project.build.finalName}.pdf</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -69,6 +78,7 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
+                            <outputFile>${project.build.finalName}.html</outputFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -78,10 +88,11 @@
                     <attributes>
                         <license>Apache License v2.0</license>
                     </attributes>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                    <skip>${asciidoctor.skip}</skip>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
 
 </project>


### PR DESCRIPTION
The build now generates additional pdf and build artifacts, which can be deployed to a maven repo.

If deployed, they can even be accessed as a maven depepndency, like:

```
        <dependency>
            <groupId>org.eclipse.microprofile.config</groupId>
            <artifactId>microprofile-config-spec</artifactId>
            <type>pdf</type>
        </dependency>
```