### PR TITLE
[API] Add ConfigBuilder#withConverter(Class, int, Converter)

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
@@ -59,7 +59,7 @@ public interface ConfigBuilder {
      * @return the ConfigBuilder with the autodiscovered config sources
      */
     ConfigBuilder addDiscoveredSources();
-    
+
     /**
      * Add the converters to be loaded via service loader pattern
      *
@@ -84,15 +84,29 @@ public interface ConfigBuilder {
 
     /**
      * Add the specified {@link Converter}.
-     * This method uses reflection to determine what type the converter is for. 
-     * Custom converters should not be created as a lambda expression, 
-     * as lambda expressions do not offer enough type information to the reflection API. 
-     * Explicit implementation of a Converter interface is required for a custom converter.
+     * This method uses reflection to determine what type the converter is for.
+     * When using lambda expressions for custom converters you should use
+     * {@link #withConverter(Class, int, Converter)} and pass the target type explicitly
+     * as lambda expressions do not offer enough type information to the reflection API.
      *
      * @param converters the converters
      * @return the ConfigBuilder with the added converters
      */
     ConfigBuilder withConverters(Converter<?>... converters);
+
+
+    /**
+     * Add the specified {@link Converter} for the given type.
+     * This method does not rely on reflection to determine what type the converter is for
+     * therefore also lambda expressions can be used.
+     *
+     * @param type the Class of type to convert
+     * @param priority the priority of the converter (custom converters have a default priority of 100).
+     * @param converter the converter (can not be {@code null})
+     * @param <T> the type to convert
+     * @return the ConfigBuilder with the added converters
+     */
+    <T> ConfigBuilder withConverter(Class<T> type, int priority, Converter<T> converter);
 
     /**
      * Build the {@link Config} object.

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/Donald.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/Donald.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.eclipse.microprofile.config.tck.converters;
+
+/**
+ * Class, which is converted using a Lambda based converter.
+ *
+ * @author <a href="mailto:anatole@apache.org">Anatole Tresch</a>
+ */
+public class Donald {
+
+    private String name;
+    private boolean bool;
+
+    private Donald(String name, boolean bool) {
+        this.name = name;
+        this.bool = bool;
+    }
+
+    /**
+     * Ensure constructor cannot be auto-detected/auto-constructed.
+     * @param name the name, not null
+     * @return a new instance, never null.
+     */
+    public static Donald iLikeDonald(String name){
+        return new Donald(name, true);
+    }
+
+    public String getName(){
+        return name;
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/UpperCaseDuckConverter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/UpperCaseDuckConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.eclipse.microprofile.config.tck.converters;
+
+import javax.annotation.Priority;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * Always create a duck with an upper case name
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a>
+ */
+@Priority(101)
+public class UpperCaseDuckConverter implements Converter<Duck> {
+    @Override
+    public Duck convert(String value) {
+        return new Duck(value.toUpperCase());
+    }
+}

--- a/tck/src/main/resources/internal/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/internal/META-INF/microprofile-config.properties
@@ -100,6 +100,9 @@ tck.config.test.javaconfig.configvalue.double=12.34567890123456
 # Custom Converter tests
 tck.config.test.javaconfig.converter.duckname=Hannelore
 
+# Lambda converter tests
+tck.config.test.javaconfig.converter.donaldname=Duck
+
 # URL Converter tests
 tck.config.test.javaconfig.converter.urlvalue=http://microprofile.io
 tck.config.test.javaconfig.converter.urlvalue.broken=tt:--location


### PR DESCRIPTION
* This method can be used to provide converter using lambda expressions
* add TCK test to check lambda converters
* add TCK text to check priority of lambda and custom converters

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>