### PR TITLE
use config 1.1 as baseline so that more RC can be released

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -98,7 +98,12 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
-                <version>3.5.0</version>                
+                <version>3.5.0</version>
+                <configuration>
+                    <base>
+                        <version>1.1</version>
+                    </base>
+                 </configuration>
                 <executions>
                     <execution>
                         <id>baseline</id>


### PR DESCRIPTION
Signed-off-by: Emily Jiang <emijiang@uk.ibm.com>