### PR TITLE
[TCK] add missing UpperCaseDuckConverter

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConverterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConverterTest.java
@@ -68,7 +68,7 @@ public class ConverterTest extends Arquillian {
                 .create(JavaArchive.class, "converterTest.jar")
                 .addClass(ConverterTest.class)
                 .addPackage(CustomDbConfigSource.class.getPackage())
-                .addClasses(DuckConverter.class, Duck.class, Donald.class)
+                .addClasses(DuckConverter.class, Duck.class, Donald.class, UpperCaseDuckConverter.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsServiceProvider(ConfigSource.class, CustomDbConfigSource.class)
                 .addAsServiceProvider(ConfigSourceProvider.class, CustomConfigSourceProvider.class)


### PR DESCRIPTION
The UpperCaseDuckConverter needs to be added to the deployed archive so that app server
can properly load it