### PR TITLE
Use a doPriv to get the parent classloader

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigProviderResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigProviderResolver.java
@@ -137,7 +137,13 @@ public abstract class ConfigProviderResolver {
         }
 
         // start from the root CL and go back down to the TCCL
-        ConfigProviderResolver instance = loadSpi(cl.getParent());
+        ClassLoader parentcl = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            @Override
+            public ClassLoader run() {
+                return cl.getParent();
+            }
+        });
+        ConfigProviderResolver instance = loadSpi(parentcl);
 
         if (instance == null) {
             ServiceLoader<ConfigProviderResolver> sl = ServiceLoader.load(


### PR DESCRIPTION
Signed-off-by: Tom Evans <tevans@uk.ibm.com>

Java 2 permissions are required to get the parent classloader.