### PR TITLE
Fixes #331 by adding links property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
+        <links>https://osgi.org/javadoc/r6/annotation/</links>
+        
         <checkstyle.version>2.17</checkstyle.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
     </properties>


### PR DESCRIPTION
This pull requests merely adds a `<links>` element under the `<properties>` element in the `pom.xml` file.  The `maven-javadoc-plugin` defines the `links` user property to contain a comma-separated list of URLs from which `package-list` may be downloaded.  This pull request ensures that https://osgi.org/javadoc/r6/annotation/ is among that list so that OSGi annotations present in the api module will be properly linked in the Javadoc output.