### PR TITLE
Clarification and test for using converters and injected config

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -47,8 +47,8 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * The config objects produced via the injection model <pre>@Inject Config</pre> are guaranteed to be serializable, while
  * the programmatically created ones are not required to be serializable.
  * <p>
- * If one or more converters are registered for a class of a requested value then one of the registered converters
- * is used to convert the string value retrieved from config sources. 
+ * If one or more converters are registered for a class of a requested value then one of the registered converters 
+ * which has the highest priority is used to convert the string value retrieved from config sources. The highest priority means the highest priority number.
  * For more information about converters, see {@link org.eclipse.microprofile.config.spi.Converter}
  *
  * <h3>Usage</h3>

--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -90,8 +90,6 @@ public interface Config {
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
      * 
-     * Registered converters are applied if they match the propertyType class
-     *
      * If this method gets used very often then consider to locally store the configured value.
      *
      * @param <T>
@@ -110,8 +108,6 @@ public interface Config {
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
      *     
-     * Registered converters are applied if they match the propertyType class
-     * 
      * If this method is used very often then consider to locally store the configured value.
      *
      * @param <T>

--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -48,7 +48,8 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * the programmatically created ones are not required to be serializable.
  * <p>
  * If one or more converters are registered for a class of a requested value then one of the registered converters 
- * which has the highest priority is used to convert the string value retrieved from config sources. The highest priority means the highest priority number.
+ * which has the highest priority is used to convert the string value retrieved from config sources. 
+ * The highest priority means the highest priority number.
  * For more information about converters, see {@link org.eclipse.microprofile.config.spi.Converter}
  *
  * <h3>Usage</h3>

--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -46,6 +46,10 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * <p>
  * The config objects produced via the injection model <pre>@Inject Config</pre> are guaranteed to be serializable, while
  * the programmatically created ones are not required to be serializable.
+ * <p>
+ * If one or more converters are registered for a class of a requested value then one of the registered converters
+ * is used to convert the string value retrieved from config sources. 
+ * For more information about converters, see {@link org.eclipse.microprofile.config.spi.Converter}
  *
  * <h3>Usage</h3>
  *
@@ -85,6 +89,8 @@ public interface Config {
     /**
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
+     * 
+     * Registered converters are applied if they match the propertyType class
      *
      * If this method gets used very often then consider to locally store the configured value.
      *
@@ -104,6 +110,8 @@ public interface Config {
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
      *     
+     * Registered converters are applied if they match the propertyType class
+     * 
      * If this method is used very often then consider to locally store the configured value.
      *
      * @param <T>

--- a/api/src/main/java/org/eclipse/microprofile/config/ConfigProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/ConfigProvider.java
@@ -79,6 +79,10 @@ public final class ConfigProvider {
     /**
      * Provide a {@link Config} based on all {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources} of the
      * current Thread Context ClassLoader (TCCL)
+     * <p>
+     * 
+     * <p>
+     * 
      * The {@link Config} will be stored for future retrieval.
      * <p>
      * There is exactly a single Config instance per ClassLoader

--- a/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
@@ -32,9 +32,13 @@ import javax.enterprise.util.Nonbinding;
 import javax.inject.Qualifier;
  
 /**
+ * <p>
  * Binds the injection point with a configured value.
  * Can be used to annotate injection points of type {@code TYPE}, {@code Optional<TYPE>} or {@code javax.inject.Provider<TYPE>},
  * where {@code TYPE} can be {@code String} and all types which have appropriate converters.
+ * <p>
+ * Injected values are the same values that would be retrieved from an injected {@link org.eclipse.microprofile.config.Config} instance 
+ * or from the instance retrieved from {@link org.eclipse.microprofile.config.ConfigProvider#getConfig()}
  *
  * <h2>Examples</h2>
  *

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
@@ -51,7 +51,7 @@ package org.eclipse.microprofile.config.spi;
  *
  * <p>A Converter can specify a {@code javax.annotation.Priority}.
  * If no priority is explicitly assigned, the value of 100 is assumed.
- * If multiple Converters are registered for the same type, the one with the highest priority will be used.
+ * If multiple Converters are registered for the same type, the one with the highest priority will be used. Highest number means highest priority.
  *
  * <p>Custom Converters can also be registered programmatically via `ConfigBuilder#withConverters(Converter... converters)` or
  * `ConfigBuilder#withConverter(Class type, int priority, Converter converter)`.

--- a/spec/src/main/asciidoc/configprovider.asciidoc
+++ b/spec/src/main/asciidoc/configprovider.asciidoc
@@ -26,23 +26,27 @@ For using Microprofile-Config in a programmatic way the `ConfigProvider` class i
 It allows access to different configurations (represented by a `Config` instance) based on the application in which it is used.
 The `ConfigProvider` internally delegates through to the `ConfigProviderResolver` which contains more low-level functionality.
 
-There are 4 different ways to create an `Config` instance:
+There are 4 different ways to create a `Config` instance:
 
-* In CDI managed components a user can use `@Inject` to access the current application configuration.
+* In CDI managed components, a user can use `@Inject` to access the current application configuration.
   The default and the auto discovered <<configsource,ConfigSources>> will be gathered to form a configuration.
+  The default and the auto discovered <<converters,Converters>> will be gathered to form a configuration.
+  Injected instance of `Config` should behave the same as the one retrieved by `ConfigProvider.getConfig()`. Injected values should be the same as if retrieved from the injected `Config` instance.
 
 * A factory method `ConfigProvider#getConfig()` to create a `Config` object based on automatically picked up `ConfigSources`
   of the Application identified by the current Thread Context ClassLoader classpath.
+  The default and the auto discovered <<converters,Converters>> will be gathered to form a configuration.
   Subsequent calls to this method for a certain Application will return the same `Config` instance.
 
 * A factory method `ConfigProvider#getConfig(ClassLoader forClassLoader)` to create a `Config`   object based on automatically picked up `ConfigSources`
   of the Application identified by the given ClassLoader.
+  The default and the auto discovered <<converters,Converters>> will be gathered to form a configuration.
   This can be used if the Thread Context ClassLoader does not represent the correct layer.
   E.g. if you need the Config for a class in a shared EAR lib folder.
   Subsequent calls to this method for a certain Application will return the same `Config` instance.
 
 * A factory method `ConfigProviderResolver#getBuilder()` to create a `ConfigBuilder` object.
-The builder has no config sources but with only the default converters added. The `ConfigBuilder` object can be filled manually via `ConfigBuilder#withSources(ConfigSources... sources)`.
+The builder has no config sources. Only the default converters are added. The `ConfigBuilder` object can be filled manually via methods like `ConfigBuilder#withSources(ConfigSources... sources)`.
    This configuration instance will by default not be shared by the `ConfigProvider`.
   This method is intended be used if a IoC container or any other external Factory can be used to give access to a manually created shared `Config`.
 

--- a/spec/src/main/asciidoc/configprovider.asciidoc
+++ b/spec/src/main/asciidoc/configprovider.asciidoc
@@ -31,7 +31,7 @@ There are 4 different ways to create a `Config` instance:
 * In CDI managed components, a user can use `@Inject` to access the current application configuration.
   The default and the auto discovered <<configsource,ConfigSources>> will be gathered to form a configuration.
   The default and the auto discovered <<converters,Converters>> will be gathered to form a configuration.
-  Injected instance of `Config` should behave the same as the one retrieved by `ConfigProvider.getConfig()`. Injected values should be the same as if retrieved from the injected `Config` instance.
+  Injected instance of `Config` should behave the same as the one retrieved by `ConfigProvider.getConfig()`. Injected config property values should be the same as if retrieved from the injected `Config` instance.
 
 * A factory method `ConfigProvider#getConfig()` to create a `Config` object based on automatically picked up `ConfigSources`
   of the Application identified by the current Thread Context ClassLoader classpath.

--- a/spec/src/main/asciidoc/configprovider.asciidoc
+++ b/spec/src/main/asciidoc/configprovider.asciidoc
@@ -31,7 +31,8 @@ There are 4 different ways to create a `Config` instance:
 * In CDI managed components, a user can use `@Inject` to access the current application configuration.
   The default and the auto discovered <<configsource,ConfigSources>> will be gathered to form a configuration.
   The default and the auto discovered <<converters,Converters>> will be gathered to form a configuration.
-  Injected instance of `Config` should behave the same as the one retrieved by `ConfigProvider.getConfig()`. Injected config property values should be the same as if retrieved from the injected `Config` instance.
+  Injected instance of `Config` should behave the same as the one retrieved by `ConfigProvider.getConfig()`. 
+  Injected config property values should be the same as if retrieved from an injected `Config` instance via `Config.getValue()`.
 
 * A factory method `ConfigProvider#getConfig()` to create a `Config` object based on automatically picked up `ConfigSources`
   of the Application identified by the current Thread Context ClassLoader classpath.

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -83,6 +83,12 @@
             <artifactId>testng</artifactId>
             <version>6.9.9</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -85,11 +85,25 @@
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        
+        <!-- add correct junit dependency for testng, which doesn't bundle hamcrest -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit-dep</artifactId>
+            <version>4.10</version>
+            <exclusions>
+                <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPlainInjectionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPlainInjectionTest.java
@@ -43,6 +43,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
@@ -63,11 +64,15 @@ public class CDIPlainInjectionTest extends Arquillian {
                 .addAsServiceProvider(ConfigSource.class, TestConfigSource.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
+    
+    @BeforeTest
+    public void setUpTest() {
+        clearAllPropertyValues();
+        ensureAllPropertyValuesAreDefined();
+    }
 
     @Test
     public void canInjectSimpleValuesWhenDefined() {
-        ensureAllPropertyValuesAreDefined();
-
         SimpleValuesBean bean = getBeanOfType(SimpleValuesBean.class);
 
         assertThat(bean.stringProperty, is(equalTo("text")));
@@ -91,8 +96,6 @@ public class CDIPlainInjectionTest extends Arquillian {
      */
     @Test
     public void injectedValuesAreEqualToProgrammaticValues() {
-        ensureAllPropertyValuesAreDefined();
-
         SimpleValuesBean bean = getBeanOfType(SimpleValuesBean.class);
 
         assertThat(bean.stringProperty, is(equalTo(
@@ -115,23 +118,16 @@ public class CDIPlainInjectionTest extends Arquillian {
 
     @Test
     public void canInjectDynamicValuesViaCdiProvider() {
-        clearAllPropertyValues();
 
         DynamicValuesBean bean = getBeanOfType(DynamicValuesBean.class);
 
         //X TODO clarify how Provider<T> should behave for missing values assertThat(bean.getIntProperty(), is(nullValue()));
-
-        ensureAllPropertyValuesAreDefined();
 
         assertThat(bean.getIntProperty(), is(equalTo(5)));
     }
 
     @Test
     public void canInjectDefaultPropertyPath() {
-        clearAllPropertyValues();
-
-        ensureAllPropertyValuesAreDefined();
-
         DefaultPropertyBean bean = getBeanOfType(DefaultPropertyBean.class);
 
         assertThat(bean.getConfigProperty(), is(equalTo("pathConfigValue")));

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/matchers/AdditionalMatchers.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/matchers/AdditionalMatchers.java
@@ -53,6 +53,11 @@ public final class AdditionalMatchers {
             public void describeTo(Description description) {
                 doubleMatcher.describeTo(description);
             }
+
+            @Override
+            public void describeMismatch(Object item, Description mismatchDescription) {
+                doubleMatcher.describeMismatch(item, mismatchDescription);
+            }
         };
     }
 


### PR DESCRIPTION
Registered converters are applied in getValue() methods. Default config and injected config are equal (plus test). Default config registers discovered converters.

Also renamed test methods from using underscores to camelCase to align to other test code.

Fixes #348.