### PR TITLE
Refactor #384

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigAccessorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigAccessorTest.java
@@ -197,6 +197,21 @@ public class ConfigAccessorTest extends Arquillian {
     }
 
     @Test
+    public void testOnAttributeChange() {
+        String key = "tck.config.test.onattributechange.key";
+        ConfigurableConfigSource.configure(config, key, "firstvalue");
+
+        ConfigAccessor<String> val = config.access(key, String.class).cacheFor(Duration.ofMillis(30)).build();
+        Assert.assertEquals(val.getValue(), "firstvalue");
+
+        // immediately change the value on the ConfigurableConfigSource that will notify the Config of the change
+        ConfigurableConfigSource.configure(config, key, "secondvalue");
+
+        // we should see the new value right now as the ConfigurableConfigSource has notified that its attribute has changed
+        Assert.assertEquals(val.getValue(), "secondvalue");
+    }
+
+    @Test
     public void testDefaultValue() {
         String key = "tck.config.test.javaconfig.somerandom.default.key";
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/ConfigurableConfigSource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/ConfigurableConfigSource.java
@@ -64,14 +64,15 @@ public class ConfigurableConfigSource implements ConfigSource {
     @Override
     public ConfigSource.ChangeSupport onAttributeChange(Consumer<Set<String>> reportAttributeChange) {
         this.reportAttributeChange = reportAttributeChange;
-        return ChangeSupport.SUPPORTED;
+        return () -> ChangeSupport.Type.SUPPORTED;
     }
 
     public static void configure(Config cfg, String propertyName, String value) {
         for (ConfigSource configSource : cfg.getConfigSources()) {
             if (configSource instanceof ConfigurableConfigSource) {
-                ((ConfigurableConfigSource) configSource).properties.put(propertyName, value);
-                ((ConfigurableConfigSource) configSource).reportAttributeChange.accept(Collections.singleton(propertyName));
+                ConfigurableConfigSource configurableConfigSource = (ConfigurableConfigSource) configSource;
+                configurableConfigSource.properties.put(propertyName, value);
+                configurableConfigSource.reportAttributeChange.accept(Collections.singleton(propertyName));
                 return;
             }
         }


### PR DESCRIPTION
Update the onAttributeChange method to return a ChangeSupport class that
can be used to handle release of resources (in the close method).

When a Config is released, it should call ChangeSupport.close to ensure
that the ConfigSource has a chance to properly release any resources
held by the callbacks.

* Add TCK test ConfigAccessorTest#testOnAttributeChange

Signed-off-by: Jeff Mesnil <jmesnil@gmail.com>