### PR TITLE
Add ConfigurableConfigSource.class to tck archive

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigAccessorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigAccessorTest.java
@@ -49,6 +49,7 @@ public class ConfigAccessorTest extends Arquillian {
             .create(JavaArchive.class, "configValueTest.jar")
             .addPackage(AbstractTest.class.getPackage())
             .addClass(ConfigAccessorTest.class)
+            .addClass(ConfigurableConfigSource.class)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsServiceProvider(ConfigSource.class, ConfigurableConfigSource.class)
             .as(JavaArchive.class);


### PR DESCRIPTION
Signed-off-by: Tom Evans <tevans@uk.ibm.com>

ConfigurableConfigSource was referenced via the ConfigSource Service Loader but the class was missing from the archive.