### PR TITLE
Added a test to the TCK to ensure observer method injection points are also validated

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/ConfigObserver.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/ConfigObserver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.config.tck.broken;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * A bean supporting the {@link
+ * MissingValueOnObserverMethodInjectionTest} test that injects a
+ * non-existent configuration property in a container lifecycle event
+ * observer method.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ *
+ * @see MissingValueOnObserverMethodInjectionTest
+ */
+@ApplicationScoped
+final class ConfigObserver {
+
+    private ConfigObserver() {
+        super();
+    }
+
+    private static final void onStartup(@Observes @Initialized(ApplicationScoped.class)
+                                        final Object event,
+                                        @ConfigProperty(name = "this.property.does.not.exist")
+                                        final String nonExistentConfigurationPropertyValue) {
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/MissingValueOnObserverMethodInjectionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/MissingValueOnObserverMethodInjectionTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.config.tck.broken;
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * A test to verify that a {@link
+ * org.eclipse.microprofile.config.inject.ConfigProperty}-annotated
+ * injection point in an observer method with a payload that is not an
+ * instance of {@link java.util.Optional} that does not have a
+ * corresponding configuration property value set will cause a {@link
+ * DeploymentException} to be thrown.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ */
+public class MissingValueOnObserverMethodInjectionTest extends Arquillian {
+
+    @ShouldThrowException(DeploymentException.class)
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "missingValueOnObserverMethodInjectionTest.jar")
+                .addClass(ConfigObserver.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
+
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "missingValueOnObserverMethodInjectionTest.war")
+                .addAsLibrary(testJar);
+        return war;
+    }
+
+    @Test
+    public void test() {
+    }
+
+}


### PR DESCRIPTION
This pull request adds a test that ensures that observer method injection points are also validated.

Suppose you have this:

    private static final void onStartup(@Observes @Initialized(ApplicationScoped.class) final Object event,
                                        @ConfigProperty("this.property.does.not.exist") final String value) {
        // do something
    }

…you want a `DeploymentException` to be thrown in this case.  I hope this is useful.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>