### PR TITLE
[#394] Fix ordinal values in Javadoc

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/package-info.java
@@ -41,8 +41,8 @@
  * <p>By default there are 3 ConfigSources:
  *
  * <ul>
- * <li>{@code System.getenv()} (ordinal=400)</li>
- * <li>{@code System.getProperties()} (ordinal=300)</li>
+ * <li>{@code System.getProperties()} (ordinal=400)</li>
+ * <li>{@code System.getenv()} (ordinal=300)</li>
  * <li>all {@code META-INF/microprofile-config.properties} files on the ClassPath.
  *  (ordinal=100, separately configurable via a config_ordinal property inside each file)</li>
  * </ul>


### PR DESCRIPTION
This fixes https://github.com/eclipse/microprofile-config/issues/394