### PR TITLE
[#414] Revert ChangeSupport enum changes

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigAccessorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigAccessorTest.java
@@ -202,7 +202,7 @@ public class ConfigAccessorTest extends Arquillian {
         String key = "tck.config.test.onattributechange.key";
         ConfigurableConfigSource.configure(config, key, "firstvalue");
 
-        ConfigAccessor<String> val = config.access(key, String.class).cacheFor(Duration.ofMillis(30)).build();
+        ConfigAccessor<String> val = config.access(key, String.class).cacheFor(Duration.ofMinutes(30)).build();
         Assert.assertEquals(val.getValue(), "firstvalue");
 
         // immediately change the value on the ConfigurableConfigSource that will notify the Config of the change

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/ConfigurableConfigSource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/ConfigurableConfigSource.java
@@ -64,7 +64,7 @@ public class ConfigurableConfigSource implements ConfigSource {
     @Override
     public ConfigSource.ChangeSupport onAttributeChange(Consumer<Set<String>> reportAttributeChange) {
         this.reportAttributeChange = reportAttributeChange;
-        return () -> ChangeSupport.Type.SUPPORTED;
+        return ChangeSupport.SUPPORTED;
     }
 
     public static void configure(Config cfg, String propertyName, String value) {


### PR DESCRIPTION
Revert back to a simple ChangeSupport enum.
Add to the ConfigSource javadoc that a ConfigSource belongs to a single
Config.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>