### PR TITLE
[#380] Fix default ConfigSources list

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
@@ -40,18 +40,19 @@ import java.util.Set;
  * The default config sources always available by default are:
  * <ol>
  * <li>System properties (ordinal=400)</li>
- * <li>Environment properties (ordinal=300)
- *    <p>Depending on the operating system type, environment variables with '.' are not always allowed.
- *    This ConfigSource searches 3 environment variables for a given property name (e.g. {@code "com.ACME.size"}):</p>
- *        <ol>
- *            <li>Exact match (i.e. {@code "com.ACME.size"})</li>
- *            <li>Replace all '.' by '_' (i.e. {@code "com_ACME_size"})</li>
- *            <li>Replace all '.' by '_' and convert to upper case (i.e. {@code "COM_ACME_SIZE"})</li>
- *        </ol>
- *    <p>The first environment variable that is found is returned by this ConfigSource.</p>
- * </li>
+ * <li>Environment properties (ordinal=300)</li>
  * <li>/META-INF/microprofile-config.properties (ordinal=100)</li>
  * </ol>
+ * </p>
+ *
+ * <p>Depending on the operating system type, environment variables with '.' are not always allowed.
+ *    This ConfigSource searches 3 environment variables for a given property name (e.g. {@code "com.ACME.size"}):</p>
+ * <ol>
+ *   <li>Exact match (i.e. {@code "com.ACME.size"})</li>
+ *   <li>Replace each character that is neither alphanumeric nor '\_' with '_' (i.e. {@code "com_ACME_size"})</li>
+ *   <li>Replace each character that is neither alphanumeric nor '\_' with '_'; then convert the name to upper case (i.e. {@code "COM_ACME_SIZE"})</li>
+ * </ol>
+ *  <p>The first environment variable that is found is returned by this ConfigSource.</p>
  *
  * <p>Custom ConfigSource will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
  * providing a file

--- a/spec/src/main/asciidoc/configsources.asciidoc
+++ b/spec/src/main/asciidoc/configsources.asciidoc
@@ -57,21 +57,21 @@ A Microprofile-Config implementation must provide <<ConfigSource,ConfigSources>>
 
 * System properties (default ordinal=400).
 * Environment variables (default ordinal=300).
-+
+* A `ConfigSource` for each property file `META-INF/microprofile-config.properties` found on the classpath. (default ordinal = 100).
+
 [[default_configsources.env.mapping]]
+==== Environment Variables Mapping Rules
 
 Some operating systems allow only alphabetic characters or an underscore, `_`, in environment variables. Other characters such as `., /`, etc may be disallowed. In order to set a value for a config property that has a name containing such disallowed characters from an environment variable, the following rules are used.
 
-This `ConfigSource` searches 3 environment variables for a given property name (e.g. `com.ACME.size`):
+The `ConfigSource` for the environment variables searches three environment variables for a given property name (e.g. `com.ACME.size`):
 
   1. Exact match (i.e. `com.ACME.size`)
-  2. Replace the character that is neither alphanumeric nor `\_` with `_` (i.e. `com_ACME_size`)
-  3. Replace the character that is neither alphanumeric nor `\_` with `_` and convert to upper case (i.e. `COM_ACME_SIZE`)
+  2. Replace each character that is neither alphanumeric nor `\_` with `_` (i.e. `com_ACME_size`)
+  3. Replace each character that is neither alphanumeric nor `\_` with `_`; then convert the name to upper case (i.e. `COM_ACME_SIZE`)
 
-+
 The first environment variable that is found is returned by this `ConfigSource`.
 
-* A `ConfigSource` for each property file `META-INF/microprofile-config.properties` found on the classpath. (default ordinal = 100).
 
 [[custom_configsources]]
 === Custom ConfigSources


### PR DESCRIPTION
List all 3 default ConfigSource first and then add a subsection about
the mapping rule specific to the Env variables.

This fixes #380.

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>