### PR TITLE
Empty values option 1

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -34,6 +34,7 @@ package org.eclipse.microprofile.config;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
 
 /**
  * <p>
@@ -44,23 +45,28 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * <p>If multiple {@link ConfigSource ConfigSources} are specified with
  * the same ordinal, the {@link ConfigSource#getName()} will be used for sorting.
  * <p>
- * The config objects produced via the injection model <pre>@Inject Config</pre> are guaranteed to be serializable, while
+ * The config objects produced via the injection model {@code @Inject Config} are guaranteed to be serializable, while
  * the programmatically created ones are not required to be serializable.
  * <p>
- * If one or more converters are registered for a class of a requested value then one of the registered converters 
- * which has the highest priority is used to convert the string value retrieved from config sources. 
+ * If one or more converters are registered for a class of a requested value, then the registered converter
+ * which has the highest priority is used to convert the string value retrieved from config sources.
  * The highest priority means the highest priority number.
- * For more information about converters, see {@link org.eclipse.microprofile.config.spi.Converter}
+ * For more information about converters, see {@link org.eclipse.microprofile.config.spi.Converter}.
+ * <p>
+ * Alternatively, an explicit converter can be given.  The converter might be independent or it might wrap a converter
+ * returned from the {@link #getConverter(Class)} method.
  *
  * <h3>Usage</h3>
  *
  * For accessing the config you can use the {@link ConfigProvider}:
  *
  * <pre>
- * public void doSomething(
+ * public void doSomething() {
  *   Config cfg = ConfigProvider.getConfig();
  *   String archiveUrl = cfg.getString("my.project.archive.endpoint", String.class);
  *   Integer archivePort = cfg.getValue("my.project.archive.port", Integer.class);
+ *   // ...
+ * }
  * </pre>
  *
  * <p>It is also possible to inject the Config if a DI container is available:
@@ -72,7 +78,14 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * }
  * </pre>
  *
- * <p>See {@link #getValue(String, Class)} and {@link #getOptionalValue(String, Class)} for accessing a configured value.
+ * <p>
+ * The {@code getValue(*)} and {@code getOptionalValue(*)} methods can be used for simple access of configuration values.
+ * <p>
+ * To access a configuration value providing a default, the {@code getValueWithDefault(*)} and {@code getOptionalValueWithDefault(*)}
+ * methods allow a typed default to be specified, whereas the {@code getValueWithDefaultString(*)} and {@code getOptionalValueWithDefaultString(*)}
+ * methods allow an unconverted default value string to be given.  If the value is not found in the configuration, then
+ * instead of returning an empty value or throwing {@code NoSuchElementException}, these methods will return the
+ * default value given on the method call.
  *
  * <p>Configured values can also be accessed via injection.
  * See {@link org.eclipse.microprofile.config.inject.ConfigProperty} for more information.
@@ -82,7 +95,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * @author <a href="mailto:rsmeral@apache.org">Ron Smeral</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:gunnar@hibernate.org">Gunnar Morling</a>
- *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 @org.osgi.annotation.versioning.ProviderType
 public interface Config {
@@ -91,20 +104,105 @@ public interface Config {
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
      * <p>
-     * If this method gets used very often then consider to locally store the configured value.
+     * If this method gets used very often, consider locally storing the configured value.
      *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration propertyName.
-     * @param propertyType
-     *             The type into which the resolve property value should get converted
-     * @return the resolved property value as an object of the requested type.
-     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param propertyType the type into which the resolved property value should be converted (must not be {@code null})
+     * @return the resolved property value as an object of the requested type
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
      * @throws java.util.NoSuchElementException if the property isn't present in the configuration, or is present
-     *  but has an empty value.
+     *  but has an empty value
      */
     <T> T getValue(String propertyName, Class<T> propertyType);
+
+    /**
+     * Return the resolved property value with the specified type for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.
+     * <p>
+     * If this method gets used very often, consider locally storing the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param propertyType the type into which the resolved property value should be converted (must not be {@code null})
+     * @param defaultValue the default value to return if no property with the given name is found
+     * @return the resolved property value as an object of the requested type
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     * @throws java.util.NoSuchElementException if the property has an empty value
+     */
+    <T> T getValueWithDefault(String propertyName, Class<T> propertyType, T defaultValue);
+
+    /**
+     * Return the resolved property value with the specified type for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.  The default value will be converted into the target type
+     * only if the property is not found.
+     * <p>
+     * If this method gets used very often, consider locally storing the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param propertyType the type into which the resolved property value should be converted (must not be {@code null})
+     * @param defaultValue the default value to convert and return if no property with the given name is found (must not be {@code null})
+     * @return the resolved property value as an object of the requested type
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     * @throws java.util.NoSuchElementException if the property has an empty value, or the property is not present
+     *      and the default value string is empty
+     */
+    <T> T getValueWithStringDefault(String propertyName, Class<T> propertyType, String defaultValue);
+
+    /**
+     * Return the resolved property value with the specified converter for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}.
+     * <p>
+     * If this method gets used very often, consider locally storing the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param converter the converter to use to convert the value (must not be {@code null})
+     * @return the resolved property value as converted by the given converter
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration, or is present
+     *  but has an empty value
+     */
+    <T> T getValue(String propertyName, Converter<T> converter);
+
+    /**
+     * Return the resolved property value with the specified converter for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.
+     * <p>
+     * If this method gets used very often, consider locally storing the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param converter the converter to use to convert the value (must not be {@code null})
+     * @param defaultValue the default value to return if no property with the given name is found
+     * @return the resolved property value as converted by the given converter
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     * @throws java.util.NoSuchElementException if the property has an empty value
+     */
+    <T> T getValueWithDefault(String propertyName, Converter<T> converter, T defaultValue);
+
+    /**
+     * Return the resolved property value with the specified converter for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.  The default value will be converted into the target type
+     * only if the property is not found.
+     * <p>
+     * If this method gets used very often, consider locally storing the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param converter the converter to use to convert the value (must not be {@code null})
+     * @param defaultValue the default value to convert and return if no property with the given name is found (must not be {@code null})
+     * @return the resolved property value as converted by the given converter
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     * @throws java.util.NoSuchElementException if the property has an empty value, or the property is not present
+     *      and the default value string is empty
+     */
+    <T> T getValueWithStringDefault(String propertyName, Converter<T> converter, String defaultValue);
 
     /**
      * Return the resolved property value with the specified type for the
@@ -113,26 +211,129 @@ public interface Config {
      * <p>
      * If this method is used very often then consider to locally store the configured value.
      *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration propertyName.
-     * @param propertyType
-     *             The type into which the resolve property value should be converted
-     * @return The resolved property value as an {@code Optional} of the requested type.
+     * @param <T> the result type
+     * @param propertyName the configuration property name
+     * @param propertyType the type into which the resolved property value should be converted
+     * @return the resolved property value as an {@code Optional} of the requested type
      *
-     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
      */
     <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType);
 
     /**
-     * Return a collection of property names.
-     * @return the names of all configured keys of the underlying configuration.
+     * Return the resolved property value with the specified type for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.  The return value will be {@linkplain Optional#empty() empty}
+     * if the value is empty or if the property is not found and the default value given is {@code null}.
+     * <p>
+     * If this method is used very often then consider to locally store the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param propertyType the type into which the resolved property value should be converted (must not be {@code null})
+     * @param defaultValue the default value to return if no property with the given name is found
+     * @return the resolved property value as an {@code Optional} of the requested type (not {@code null})
+     *
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     */
+    <T> Optional<T> getOptionalValueWithDefault(String propertyName, Class<T> propertyType, T defaultValue);
+
+    /**
+     * Return the resolved property value with the specified type for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.  The default value will be converted into the target type
+     * only if the property is not found..  The return value will be {@linkplain Optional#empty() empty} if the value
+     * is empty or if the property is not found and the default value given is empty.
+     * <p>
+     * If this method is used very often then consider to locally store the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name (must not be {@code null})
+     * @param propertyType the type into which the resolved property value should be converted (must not be {@code null})
+     * @param defaultValue the default value to convert and return if no property with the given name is found (must not be {@code null})
+     * @return the resolved property value as an {@code Optional} of the requested type (not {@code null})
+     *
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     */
+    <T> Optional<T> getOptionalValueWithStringDefault(String propertyName, Class<T> propertyType, String defaultValue);
+
+    /**
+     * Return the resolved property value with the specified converter for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}.  The
+     * return value will be {@linkplain Optional#empty() empty} if the value is empty.
+     * <p>
+     * If this method is used very often then consider to locally store the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name
+     * @param converter the converter to use to convert the value
+     * @return the resolved property value as an {@code Optional} of the requested type
+     *
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     */
+    <T> Optional<T> getOptionalValue(String propertyName, Converter<T> converter);
+
+    /**
+     * Return the resolved property value with the specified converter for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.  The return value will be {@linkplain Optional#empty() empty}
+     * if the value is empty or if the property is not found and the default value given is {@code null}.
+     * <p>
+     * If this method is used very often then consider to locally store the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name
+     * @param converter the converter to use to convert the value
+     * @param defaultValue the default value to return if no property with the given name is found
+     * @return the resolved property value as an {@code Optional} of the requested type
+     *
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     */
+    <T> Optional<T> getOptionalValueWithDefault(String propertyName, Converter<T> converter, T defaultValue);
+
+    /**
+     * Return the resolved property value with the specified converter for the
+     * specified property name from the underlying {@link ConfigSource ConfigSources}, using the given
+     * default value if the property is not found.  The default value will be converted into the target type
+     * only if the property is not found..  The return value will be {@linkplain Optional#empty() empty} if the value
+     * is empty or if the property is not found and the default value given is empty.
+     * <p>
+     * If this method is used very often then consider to locally store the configured value.
+     *
+     * @param <T> the result type
+     * @param propertyName the configuration property name
+     * @param converter the converter to use to convert the value
+     * @param defaultValue the default value to convert and return if no property with the given name is found (must not be {@code null})
+     * @return the resolved property value as an {@code Optional} of the requested type
+     *
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     */
+    <T> Optional<T> getOptionalValueWithStringDefault(String propertyName, Converter<T> converter, String defaultValue);
+
+    /**
+     * Get the converter that would be used for converting instances of the given class.  The resultant converter
+     * may be an implicit converter, a built-in converter, a global converter, or any other matching
+     * converter registered in any other implementation-specific manner.  If no converter is known or available for the
+     * given class, {@code null} is returned.
+     *
+     * @param <T> the value type
+     * @param clazz the type class (must not be {@code null})
+     * @return the converter that would be used, or {@code null} if no converter is known for the given class
+     */
+    <T> Converter<T> getConverter(Class<T> clazz);
+
+    /**
+     * Return all known property names.
+     *
+     * @return the names of all known configured keys of the underlying configuration sources
      */
     Iterable<String> getPropertyNames();
 
     /**
-     * @return all currently registered {@link ConfigSource configsources} sorted with descending ordinal and ConfigSource name
+     * Return all registered {@linkplain ConfigSource configuration sources}.  The result will be sorted
+     * by decreasing ordinal value.  If two sources have the same ordinal value, they will be ordered by name.
+     *
+     * @return all currently registered configuration sources
      */
     Iterable<ConfigSource> getConfigSources();
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -90,7 +90,7 @@ public interface Config {
     /**
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
-     * 
+     * <p>
      * If this method gets used very often then consider to locally store the configured value.
      *
      * @param <T>
@@ -101,14 +101,16 @@ public interface Config {
      *             The type into which the resolve property value should get converted
      * @return the resolved property value as an object of the requested type.
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
-     * @throws java.util.NoSuchElementException if the property isn't present in the configuration.
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration, or is present
+     *  but has an empty value.
      */
     <T> T getValue(String propertyName, Class<T> propertyType);
 
     /**
      * Return the resolved property value with the specified type for the
-     * specified property name from the underlying {@link ConfigSource ConfigSources}.
-     *     
+     * specified property name from the underlying {@link ConfigSource ConfigSources}.  The
+     * return value will be {@linkplain Optional#empty() empty} if the value is empty.
+     * <p>
      * If this method is used very often then consider to locally store the configured value.
      *
      * @param <T>
@@ -117,7 +119,7 @@ public interface Config {
      *             The configuration propertyName.
      * @param propertyType
      *             The type into which the resolve property value should be converted
-     * @return The resolved property value as an Optional of the requested type.
+     * @return The resolved property value as an {@code Optional} of the requested type.
      *
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
      */

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
@@ -1,6 +1,6 @@
 /*
  ********************************************************************************
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -24,6 +24,8 @@
  *      JavaDoc + priority
  *   2016-12-01 - Emily Jiang / IBM Corp
  *      Marking as FunctionalInterface + JavaDoc + additional types
+ *   2019-07-25 - David M. Lloyd
+ *      JavaDoc cleanups and clarification around empty value handling
  *
  *******************************************************************************/
 
@@ -31,80 +33,96 @@ package org.eclipse.microprofile.config.spi;
 
 /**
  * <p>Interface for converting configured values from String to any Java type.
- **
- * <p>Converters for the following types are provided by default:
- * <ul>
- *     <li>{@code boolean} and {@code Boolean}, values for {@code true}: (case insensitive)
- *     &quot;true&quot;, &quot;yes&quot;, &quot;Y&quot;, &quot;on&quot;, &quot;1&quot;</li>
- *     <li>{@code int} and {@code Integer}</li>
- *     <li>{@code long} and {@code Long}</li>
- *     <li>{@code float} and {@code Float}, a dot '.' is used to separate the fractional digits</li>
- *     <li>{@code double} and {@code Double}, a dot '.' is used to separate the fractional digits</li>
- *     <li>{@code java.lang.Class} based on the result of {@link java.lang.Class#forName}</li>
  *
+ * <h3>Global Converters</h3>
+ *
+ * Converters may be global to a {@code Config} instance.  Global converters are automatically applied to types that
+ * match the converter's type.
+ *
+ * <p>Global converters may be <em>built in</em>.  Such converters are provided by the implementation.  A compliant
+ * implementation must provide built-in converters for at least the following types:
+ * <ul>
+ *     <li>{@code boolean} and {@code Boolean}, returning {@code true} for at least the following values (case insensitive):
+ *     <ul>
+ *         <li>{@code true}</li>
+ *         <li>{@code yes}</li>
+ *         <li>{@code y}</li>
+ *         <li>{@code on}</li>
+ *         <li>{@code 1}</li>
+ *     </ul>
+ *     <li>{@code int} and {@code Integer}, accepting (at minimum) all values accepted by the {@link Integer#parseInt(String)} method</li>
+ *     <li>{@code long} and {@code Long}, accepting (at minimum) all values accepted by the {@link Long#parseLong(String)} method</li>
+ *     <li>{@code float} and {@code Float}, accepting (at minimum) all values accepted by the {@link Float#parseFloat(String)} method</li>
+ *     <li>{@code double} and {@code Double}, accepting (at minimum) all values accepted by the {@link Double#parseDouble(String)} method</li>
+ *     <li>{@code java.lang.Class} based on the result of {@link java.lang.Class#forName}</li>
+ *     <li>{@code java.lang.String}</li>
  * </ul>
  *
- * <p>Custom Converters will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
- * providing a file<br>
- * <code>META-INF/services/org.eclipse.microprofile.config.spi.Converter</code><br>
- * which contains the fully qualified {@code Converter} implementation class name as content.
+ * <p>Custom global converters will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
+ * providing a file named {@code META-INF/services/org.eclipse.microprofile.config.spi.Converter}
+ * which contains one or more fully qualified {@code Converter} implementation class names as content.
  *
- * <p>A Converter can specify a {@code javax.annotation.Priority}.
+ * <p>A custom global {@code Converter} implementation class may specify a {@code javax.annotation.Priority}.
  * If no priority is explicitly assigned, the value of 100 is assumed.
  * If multiple Converters are registered for the same type, the one with the highest priority will be used. Highest number means highest priority.
  *
- * <p>Custom Converters can also be registered programmatically via `ConfigBuilder#withConverters(Converter... converters)` or
- * `ConfigBuilder#withConverter(Class type, int priority, Converter converter)`.
+ * <p>Custom global converters may also be registered programmatically to a configuration builder via the
+ * {@link ConfigBuilder#withConverters(Converter[])} or {@link ConfigBuilder#withConverter(Class, int, Converter)} methods.
  *
- * All Built In Converters have a {@code javax.annotation.Priority} of 1
+ * <p>All built in converters have a {@code javax.annotation.Priority} of 1.
  * A Converter should handle null values returning either null or a valid Object of the specified type.
  *
- * <h3>Array Converters</h3>
- *  The implementation must support the Array converter for each built-in converters and custom converters.
- *  The delimiter for the config value is ",". The escape character is "\".
- *  <code>e.g. myPets=dog,cat,dog\,cat </code>
- * <p>
- *  For the property injection, List and Set should be supported as well.
+ * <p>Converters may return {@code null}, indicating that the result of the conversion is an empty value.
  *
- *  <p>
- *  Usage:
- *  <p>
- *  <code>
- *  String[] myPets = config.getValue("myPet", String[].class);
- *  </code>
- *
- *  <p>
- *  {@code @Inject @ConfigProperty(name="myPets") private String[] myPets;}
- *  <p>
- *  {@code @Inject @ConfigProperty(name="myPets") private List<String> myPets;}
- *
- *  <p>
- *  {@code @Inject @ConfigProperty(name="myPets") private Set<String> myPets;}
- *  <p>
- *  myPets will be "dog", "cat", "dog,cat"
  * <h3>Implicit Converters</h3>
  *
- * <p>If no explicit Converter and no built-in Converter could be found for a certain type,
- * the {@code Config} provides an <em>Implicit Converter</em>, if</p>
+ * <p>If no global converter could be found for a certain type,
+ * the {@code Config} implementation must provide an <em>Implicit Converter</em>, if:
  * <ul>
  *     <li>the target type {@code T} has a {@code public static T of(String)} method, or</li>
  *     <li>the target type {@code T} has a {@code public static T valueOf(String)} method, or</li>
- *     <li>the target type {@code T} has a public Constructor with a String parameter, or</li>
+ *     <li>the target type {@code T} has a public constructor with a {@code String} parameter, or</li>
  *     <li>the target type {@code T} has a {@code public static T parse(CharSequence)} method</li>
+ *     <li>the target type {@code T} is an array of any type that has an installed explicit, built-in, or implicit converter</li>
  * </ul>
-
+ *
+ * The implicit array converter uses a comma ({@code U+002C ','}) as a delimiter.  To allow a comma to be embedded within
+ * individual elements, it may be preceded by a backslash ({@code U+005C '\'}) character.  Any such escaped comma will be
+ * included within a single element (the backslash will be discarded).
+ * <p>
+ * The implicit array converter <em>must not</em> include empty segments within the conversion result.  An empty segment
+ * is defined as a segment for which the element converter has returned {@code null}.  If no elements are included, the
+ * value must be considered empty and {@code null} returned.
+ *
+ * <h3>Empty Values</h3>
+ *
+ * A {@code null} conversion result indicates that the converted value is empty.  All implicit converters defined
+ * here <em>must</em> return {@code null} when converting empty values.  All built-in global converters defined here
+ * <em>must</em> return {@code null} when converting empty values.  Other built-in global converters <em>should</em>
+ * return {@code null} when converting empty values.
+ * <p>
+ * Customized user converters and certain special built-in converters may return other values to represent empty.  However, this
+ * may be unexpected so the cases for such behavior should be clearly documented for each converter.
+ * <p>
+ * Most converters will consider an empty string value ({@code ""}) to be empty.  Some converters may yield an empty value
+ * for other inputs.
+ *
  * @author <a href="mailto:rsmeral@apache.org">Ron Smeral</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:john.d.ament@gmail.com">John D. Ament</a>
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public interface Converter<T> {
     /**
-     * Configure the string value to a specified type
-     * @param value the string representation of a property value.
-     * @return the converted value or null
+     * Configure the string value to a specified type.  If the given value string converts to an empty value,
+     * {@code null} may be returned to indicate that this is the case.  In particular, an empty input string
+     * should normally result in a {@code null} return value.
      *
-     * @throws IllegalArgumentException if the value cannot be converted to the specified type.
+     * @param value the string representation of a property value (must not be {@code null})
+     * @return the converted value or {@code null} if the result is an empty value
+     *
+     * @throws IllegalArgumentException if the value cannot be converted to the specified type
      */
     T convert(String value);
 }

--- a/spec/src/main/asciidoc/configexamples.asciidoc
+++ b/spec/src/main/asciidoc/configexamples.asciidoc
@@ -72,21 +72,21 @@ public class InjectedConfigUsageSample {
     @Inject
     private Config config;
 
-    //The property myprj.some.url must exist in one of the configsources, otherwise a
+    //The property myprj.some.url must have a non-empty value in one of the configsources, otherwise a
     //DeploymentException will be thrown.
     @Inject
     @ConfigProperty(name="myprj.some.url")
     private String someUrl;
-    //The following code injects an Optional value of myprj.some.port property. 
+    //The following code injects a possibly empty value of myprj.some.port property.
     //Contrary to natively injecting the configured value this will not lead to a 
-    //DeploymentException if the configured value is missing. 
+    //DeploymentException if the configured value is empty.
     @Inject
     @ConfigProperty(name="myprj.some.port")
     private Optional<Integer> somePort;
     //Injects a Provider for the value of myprj.some.dynamic.timeout property to 
     //resolve the property dynamically. Each invocation to Provider#get() will 
     //resolve the latest value from underlying Config.
-    //The existence of configured values will get checked during startup. 
+    //The validity of configured values will get checked during startup.
     //Instances of Provider<T> are guaranteed to be Serializable. 
     @Inject
     @ConfigProperty(name="myprj.some.dynamic.timeout", defaultValue="100")

--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -92,3 +92,50 @@ If no built-in nor custom `Converter` for a requested Type `T`, an implicit Conv
 * The target type {@code T} has a public Constructor with a String parameter, or
 * The target type {@code T} has a {@code public static T parse(CharSequence)} method
 
+=== Empty value
+
+A config property can be explicitly configured with an empty value (the empty String `""`).  If a property
+is missing and no default value exists for that property, it is considered to be empty.
+
+The `Config.getValue()` method will normally throw a `NoSuchElementException` when a configuration value
+is empty.  In order to allow empty values to be returned, either the `Config.getOptionalValue()`
+method must be used, or a custom converter must be specified which provides a specific value for
+the case where an empty value is returned (either implicitly due to the property being missing, or
+explicitly due to an empty value being specified for a configuration property).
+
+[NOTE]
+This behaviour allows users to _unconfigure_ a property. If a property is configured in a lower-ordinal ConfigSource with
+an undesirable value, you can set the property value to an empty string in a higher-ordinal ConfigSource to discard the lower-ordinal value.
+
+When processing array or collection values, any empty array or collection segments must be excluded from the
+resultant array or collection.
+
+[[empty_value_table]]
+.Examples of Config API behavior for empty values
+[options="header"]
+|=======================
+| Property value | Output type | `Config` method | Output result
+| missing     | `String` | `getValue` | throws `NoSuchElementException`
+| `""` (empty string) | `String` | `getValue` | throws `NoSuchElementException`
+| `" "`       | `String` | `getValue` | `" "`
+| `"foo"`     | `String`   | `getValue` |  `"foo"`
+| missing     | `String[]` | `getValue` | throws `NoSuchElementException`
+| `""`        | `String[]` | `getValue` | throws `NoSuchElementException`
+| `" "`       | `String[]` | `getValue` | `{ " " }`
+| `","`       | `String[]` | `getValue` | throws `NoSuchElementException`
+| `",,"`      | `String[]` | `getValue` | throws `NoSuchElementException`
+| `"foo"`     | `String[]` | `getValue` | `{ "foo" }`
+| `"foo,bar"` | `String[]` | `getValue` | `{ "foo", "bar" }`
+| `"foo,"`    | `String[]` | `getValue` | `{ "foo" }`
+| `",bar"`    | `String[]` | `getValue` | `{ "bar" }`
+| `",bar,"`   | `String[]` | `getValue` | `{ "bar" }`
+| missing     | `String` |`getOptionalValue` | `Optional.empty()`
+| `""`        | `String` | `getOptionalValue` | `Optional.empty()`
+| `" "`        | `String` | `getOptionalValue` | `Optional.of(" ")`
+| `"foo"`     | `String` | `getOptionalValue` | `Optional.of("foo")`
+| missing | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `""` | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `","` | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `",,"` | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `"foo,bar"` | `String[]` | `getOptionalValue` | `Optional.of({ "foo", "bar" })`
+|=======================

--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -92,22 +92,21 @@ If no built-in nor custom `Converter` for a requested Type `T`, an implicit Conv
 * The target type {@code T} has a public Constructor with a String parameter, or
 * The target type {@code T} has a {@code public static T parse(CharSequence)} method
 
-=== Empty value
+=== Missing value
 
-A config property can be explicitly configured with an empty value (the empty String `""`).  If a property
-is missing and no default value exists for that property, it is considered to be empty.
+A config property can be explicitly configured to indicate that a property is missing by specifying the empty String (`""`).  The property
+is then considered to be missing if no default value exists for that property.
 
 The `Config.getValue()` method will normally throw a `NoSuchElementException` when a configuration value
-is empty.  In order to allow empty values to be returned, either the `Config.getOptionalValue()`
-method must be used, or a custom converter must be specified which provides a specific value for
-the case where an empty value is returned (either implicitly due to the property being missing, or
-explicitly due to an empty value being specified for a configuration property).
+is missing.  Empty values (such as the empty string `""` or a zero-length array) cannot be returned
+unless a custom converter is specified which provides a specific value for
+the case where an empty value is desired.
 
 [NOTE]
 This behaviour allows users to _unconfigure_ a property. If a property is configured in a lower-ordinal ConfigSource with
-an undesirable value, you can set the property value to an empty string in a higher-ordinal ConfigSource to discard the lower-ordinal value.
+an undesirable value, you can set the property value to an empty string, which means missing, in a higher-ordinal ConfigSource to discard the lower-ordinal value.
 
-When processing array or collection values, any empty array or collection segments must be excluded from the
+When processing array or collection values, any missing array or collection segments must be excluded from the
 resultant array or collection.
 
 [[empty_value_table]]

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyBean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.config.tck;
+
+import static org.eclipse.microprofile.config.tck.EmptyConfigPropertyTest.EMPTY_PROP;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Dependent
+public class EmptyConfigPropertyBean {
+
+    @Inject
+    @ConfigProperty(name = EMPTY_PROP)
+    private String[] myStrings;
+
+    @Inject
+    @ConfigProperty(name = EMPTY_PROP)
+    private List<String> myStringList;
+
+    @Inject
+    @ConfigProperty(name = EMPTY_PROP)
+    private Set<String> myStringSet;
+
+    public String[] getMyStrings() {
+        return myStrings;
+    }
+
+    public List<String> getMyStringList() {
+        return myStringList;
+    }
+
+    public Set<String> getMyStringSet() {
+        return myStringSet;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.config.tck;
+
+import static org.eclipse.microprofile.config.tck.base.AbstractTest.addFile;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.tck.configsources.KeyValuesConfigSource;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class EmptyConfigPropertyTest  extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+            .create(JavaArchive.class, "EmptyConfigPropertyTest.jar")
+            .addClass(KeyValuesConfigSource.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+            .as(JavaArchive.class);
+
+        addFile(testJar, "META-INF/microprofile-config.properties");
+
+        WebArchive war = ShrinkWrap
+            .create(WebArchive.class, "EmptyConfigPropertyTest.war")
+            .addAsLibrary(testJar);
+        return war;
+    }
+
+
+    private @Inject
+    Config config;
+
+    static final String EMPTY_PROP = "tck.config.empty";
+    static final String MISSING_PROP = "tck.config.this.property.is.not.defined.anywhere";
+
+    @Test
+    public void testEmptyPropertyWithConfig() {
+        // | Property value | Output type | `Config` method | Output result
+        // | `""` (empty string) | `String` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(EMPTY_PROP, String.class);
+            Assert.fail("An empty string is considered as missing and must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        try {
+            config.getValue(EMPTY_PROP, Double.class);
+            Assert.fail(("an empty String is considered missing regardless of the output type"));
+        }
+        catch (NoSuchElementException e) {
+        }
+
+        // | `""`        | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(EMPTY_PROP, String[].class);
+            Assert.fail(("an empty String is considered missing regardless of the output type"));
+        }
+        catch (NoSuchElementException e) {
+        }
+        try {
+            config.getValue(EMPTY_PROP, Double[].class);
+            Assert.fail(("an empty String is considered missing regardless of the output type"));
+        }
+        catch (NoSuchElementException e) {
+        }
+
+
+        // | `""`        | `String` | `getOptionalValue` | `Optional.empty()`
+        assertEquals(config.getOptionalValue(EMPTY_PROP, String.class), Optional.empty());
+        assertEquals(config.getOptionalValue(EMPTY_PROP, Double.class), Optional.empty());
+
+        // | `""` | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals( config.getOptionalValue(EMPTY_PROP, String[].class), Optional.empty());
+        assertEquals( config.getOptionalValue(EMPTY_PROP, Double[].class), Optional.empty());
+    }
+
+    @Test
+    public void testMissingProperty() {
+        // | Property value | Output type | `Config` method | Output result
+        // | missing     | `String` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(MISSING_PROP, String.class);
+            Assert.fail("A missing property must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // | missing     | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(MISSING_PROP, String[].class);
+            Assert.fail("A missing property must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // regardless of the output type
+        try {
+            config.getValue(MISSING_PROP, Double[].class);
+            Assert.fail("A missing property must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+
+        // | missing     | `String` |`getOptionalValue` | `Optional.empty()`
+        assertEquals( config.getOptionalValue(MISSING_PROP, String.class), Optional.empty());
+        // | missing | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals( config.getOptionalValue(MISSING_PROP, String[].class), Optional.empty());
+    }
+
+    @Test
+    public void testArrayCommasRules() {
+        Config config = KeyValuesConfigSource.buildConfig(
+            "arrayWithSpace", " ",
+            "arrayWithSingleComma", ",",
+            "arrayWithTwoCommas", ",,",
+            "arrayWithSingleValue", "foo",
+            "arrayWithTwoValues", "foo,bar",
+            "arrayWithTrailingComma", "foo,",
+            "arrayWithLeadingComma", ",bar",
+            "arrayWithLeadingAndTrailingCommas", ",bar,");
+
+        // | Property value | Output type | `Config` method | Output result
+        // | `" "`       | `String[]` | `getValue` | `{ " " }`
+        assertEquals(config.getValue("arrayWithSpace", String[].class), new String[] { " " });
+        // | `","`       | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue("arrayWithSingleComma", String[].class);
+            Assert.fail("An array with only empty elements must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // | `",,"`      | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue("arrayWithTwoCommas", String[].class);
+            Assert.fail("An array with only empty elements must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // | `"foo"`     | `String[]` | `getValue` | `{ "foo" }`
+        assertEquals(config.getValue("arrayWithSingleValue", String[].class), new String[] { "foo" });
+        // | `"foo,bar"` | `String[]` | `getValue` | `{ "foo", "bar" }`
+        assertEquals(config.getValue("arrayWithTwoValues", String[].class), new String[] { "foo", "bar" });
+        // | `"foo,"`    | `String[]` | `getValue` | `{ "foo" }`
+        assertEquals(config.getValue("arrayWithTrailingComma", String[].class), new String[] { "foo" });
+        // | `",bar"`    | `String[]` | `getValue` | `{ "bar" }`
+        assertEquals(config.getValue("arrayWithLeadingComma", String[].class), new String[] { "bar" });
+        // | `",bar,"`   | `String[]` | `getValue` | `{ "bar" }`
+        assertEquals(config.getValue("arrayWithLeadingAndTrailingCommas", String[].class), new String[] { "bar" });
+
+        // | `","` | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals(config.getOptionalValue("arrayWithSingleComma", String[].class), Optional.empty());
+        // | `",,"` | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals(config.getOptionalValue("arrayWithTwoCommas", String[].class), Optional.empty());
+    }
+
+    @Test
+    public void testEmptyPropertyResetsLowerOrdinalProperty() {
+        Config config = ConfigProviderResolver.instance().getBuilder()
+            .withSources(
+                // lower-ordinal configures a prop
+                KeyValuesConfigSource.config(10,
+                    "my.prop", "foo"),
+                // higher-ordinal resets it with an empty string
+                KeyValuesConfigSource.config(20,
+                    "my.prop", ""))
+            .build();
+
+        try {
+            config.getValue("my.prop", String.class);
+            fail("The property must be reset by the empty string in the higher-ordinal config source");
+        }
+        catch (NoSuchElementException e) {
+        }
+
+        assertEquals(config.getOptionalValue("my.prop", String.class), Optional.empty());
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyValuesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyValuesTest.java
@@ -19,6 +19,12 @@
  */
 package org.eclipse.microprofile.config.tck;
 
+import static org.testng.Assert.assertEquals;
+
+import java.util.NoSuchElementException;
+
+import javax.inject.Inject;
+
 import org.eclipse.microprofile.config.Config;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -29,10 +35,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
-
-import javax.inject.Inject;
-
-import static org.testng.Assert.assertEquals;
 
 public class EmptyValuesTest extends Arquillian {
 
@@ -63,17 +65,30 @@ public class EmptyValuesTest extends Arquillian {
         assertEquals(emptyValuesBean.getStringValue(), "");
     }
 
-    @Test
+    @Test(expectedExceptions = NoSuchElementException.class)
     public void testEmptyStringProgrammaticLookup() {
-        System.setProperty(EMPTY_PROPERTY, "");
-        String stringValue = config.getValue(EMPTY_PROPERTY, String.class);
-        assertEquals(stringValue, "");
-        System.clearProperty(EMPTY_PROPERTY);
+        try {
+            System.setProperty(EMPTY_PROPERTY, "");
+            config.getValue(EMPTY_PROPERTY, String.class);
+        }
+        finally {
+            System.clearProperty(EMPTY_PROPERTY);
+        }
     }
 
-    @Test
+    @Test(expectedExceptions =  NoSuchElementException.class)
     public void testEmptyStringPropertyFromConfigFile() {
-        String stringValue = config.getValue(PROP_FILE_EMPTY_PROPERTY, String.class);
-        assertEquals(stringValue, "");
+        config.getValue(PROP_FILE_EMPTY_PROPERTY, String.class);
+    }
+
+    @Test(expectedExceptions = NoSuchElementException.class)
+    public void testEmptyStringLookupAsArray() {
+        try {
+            System.setProperty(EMPTY_PROPERTY, "");
+            config.getValue(EMPTY_PROPERTY, String[].class);
+        }
+        finally {
+            System.clearProperty(EMPTY_PROPERTY);
+        }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/KeyValuesConfigSource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/KeyValuesConfigSource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.config.tck.configsources;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class KeyValuesConfigSource implements ConfigSource {
+
+
+    private final Map<String, String> properties = new HashMap<>();
+    private final int ordinal;
+
+    private KeyValuesConfigSource(Map<String, String> properties, int ordinal) {
+        this.properties.putAll(properties);
+        this.ordinal = ordinal;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ordinal;
+    }
+
+    @Override
+    public String getName() {
+        return "KeyValuesConfigSource";
+    }
+
+    public static ConfigSource config(String... keyValues) {
+        return config(DEFAULT_ORDINAL, keyValues);
+    }
+
+    public static ConfigSource config(int ordinal, String... keyValues) {
+        if (keyValues.length %2 != 0) {
+            throw new IllegalArgumentException("keyValues array must be a multiple of 2");
+        }
+
+        Map<String, String> props = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            props.put(keyValues[i], keyValues[i+1]);
+        }
+        return new KeyValuesConfigSource(props, ordinal);
+    }
+
+    public static Config buildConfig(String... keyValues) {
+        return ConfigProviderResolver.instance().getBuilder()
+            .withSources(KeyValuesConfigSource.config(keyValues))
+            .build();
+    }
+}

--- a/tck/src/main/resources/internal/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/internal/META-INF/microprofile-config.properties
@@ -143,3 +143,6 @@ tck.config.test.javaconfig.converter.urlvalues=http://microprofile.io,http://ope
 
 tck.config.test.javaconfig.converter.class=org.eclipse.microprofile.config.tck.ClassConverterTest
 tck.config.test.javaconfig.converter.class.array=org.eclipse.microprofile.config.tck.ClassConverterTest,java.lang.String
+
+# empty config property test
+tck.config.empty=


### PR DESCRIPTION
This is the first option for an API to support the new consistent rules for empty value handling, by adding method overloads to the `Config` interface.  Supercedes #407.  Fixes #446.