### PR TITLE
Empty values option 2

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -34,6 +34,7 @@
 
 package org.eclipse.microprofile.config;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -90,7 +91,7 @@ public interface Config {
     /**
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
-     *
+     * <p>
      * If this method gets used very often then consider to locally store the configured value.
      *
      * @param <T>
@@ -101,14 +102,16 @@ public interface Config {
      *             The type into which the resolve property value should get converted
      * @return the resolved property value as an object of the requested type.
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
-     * @throws java.util.NoSuchElementException if the property isn't present in the configuration.
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration, or is present
+     *  but has an empty value.
      */
-    <T> T getValue(String propertyName, Class<T> propertyType);
+    <T> T getValue(String propertyName, Class<T> propertyType) throws IllegalArgumentException, NoSuchElementException;
 
     /**
      * Return the resolved property value with the specified type for the
-     * specified property name from the underlying {@link ConfigSource ConfigSources}.
-     *
+     * specified property name from the underlying {@link ConfigSource ConfigSource}s.  The
+     * return value will be {@linkplain Optional#empty() empty} if the value is empty.
+     * <p>
      * If this method is used very often then consider to locally store the configured value.
      *
      * @param <T>
@@ -117,7 +120,7 @@ public interface Config {
      *             The configuration propertyName.
      * @param propertyType
      *             The type into which the resolve property value should be converted
-     * @return The resolved property value as an Optional of the requested type.
+     * @return The resolved property value as an {@code Optional} of the requested type.
      *
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
      */

--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -38,6 +38,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
 
 /**
  * <p>
@@ -84,6 +85,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * @author <a href="mailto:rsmeral@apache.org">Ron Smeral</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:gunnar@hibernate.org">Gunnar Morling</a>
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 @org.osgi.annotation.versioning.ProviderType
 public interface Config {
@@ -131,6 +133,18 @@ public interface Config {
      * @return the names of all configured keys of the underlying configuration.
      */
     Iterable<String> getPropertyNames();
+
+    /**
+     * Get the converter that would be used for converting instances of the given class.  The resultant converter
+     * may be an implicit converter, a built-in converter, a global converter, or any other matching
+     * converter registered in any other implementation-specific manner.  If no converter is known or available for the
+     * given class, {@code null} is returned.
+     *
+     * @param <T> the value type
+     * @param clazz the type class (must not be {@code null})
+     * @return the converter that would be used, or {@code null} if no converter is known for the given class
+     */
+    <T> Converter<T> getConverter(Class<T> clazz);
 
     /**
      * @return all currently registered {@link ConfigSource ConfigSources} sorted by descending ordinal and ConfigSource name

--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -75,7 +75,8 @@ import org.eclipse.microprofile.config.spi.Converter;
  * }
  * </pre>
  *
- * <p>See {@link #getValue(String, Class)} and {@link #getOptionalValue(String, Class)} for accessing a configured value.
+ * <p>See {@link #getValue(String, Class)} and {@link #getOptionalValue(String, Class)} and
+ * {@link #access(String)} for accessing a configured value.
  *
  * <p>Configured values can also be accessed via injection.
  * See {@link org.eclipse.microprofile.config.inject.ConfigProperty} for more information.
@@ -91,23 +92,33 @@ import org.eclipse.microprofile.config.spi.Converter;
 public interface Config {
 
     /**
+     * Get a configuration accessor for the given property name.  The accessor provides a means to configure the
+     * access behavior.  The implementation may or may not cache accessor instances.
+     *
+     * @param propertyName the property name to access (must not be {@code null})
+     * @return the immutable configuration accessor (not {@code null})
+     */
+    ConfigAccessor<?> access(String propertyName);
+
+    /**
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@link ConfigSource ConfigSources}.
      * <p>
      * If this method gets used very often then consider to locally store the configured value.
      *
-     * @param <T>
-     *             The property type
+     * @param <T>  the property type
      * @param propertyName
      *             The configuration propertyName.
      * @param propertyType
      *             The type into which the resolve property value should get converted
      * @return the resolved property value as an object of the requested type.
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
-     * @throws java.util.NoSuchElementException if the property isn't present in the configuration, or is present
+     * @throws NoSuchElementException if the property isn't present in the configuration, or is present
      *  but has an empty value.
      */
-    <T> T getValue(String propertyName, Class<T> propertyType) throws IllegalArgumentException, NoSuchElementException;
+    default <T> T getValue(String propertyName, Class<T> propertyType) throws IllegalArgumentException, NoSuchElementException {
+        return access(propertyName).convertedForType(propertyType).getValue();
+    }
 
     /**
      * Return the resolved property value with the specified type for the
@@ -116,8 +127,7 @@ public interface Config {
      * <p>
      * If this method is used very often then consider to locally store the configured value.
      *
-     * @param <T>
-     *             The property type
+     * @param <T>  the property type
      * @param propertyName
      *             The configuration propertyName.
      * @param propertyType

--- a/api/src/main/java/org/eclipse/microprofile/config/ConfigAccessor.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/ConfigAccessor.java
@@ -1,0 +1,183 @@
+/*
+ ******************************************************************************
+ * Copyright (c) 2009-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *   2011-12-28 - Mark Struberg & Gerhard Petracek
+ *      Contributed to Apache DeltaSpike fb0131106481f0b9a8fd
+ *   2016-07-07 - Mark Struberg
+ *      Extracted the Config part out of DeltaSpike and proposed as Microprofile-Config 8ff76eb3bcfaf4fd
+ *
+ *******************************************************************************/
+package org.eclipse.microprofile.config;
+
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * An accessor for a configuration value.  Accessors are always immutable.  To customize
+ * the behavior of a property access, methods of this class may be called (typically in a chain)
+ * to derive successively further customized accessor instances.
+ * <p>
+ * For example, to retrieve an optional value of type {@code Integer} using a default value:
+ * <pre>
+ *  Optional&lt;Integer&gt; val = config.access("my.int.value")
+ *    .convertedForType(Integer.class)
+ *    .withDefault(123)
+ *    .optional()
+ *    .getValue();
+ * </pre>
+ * <p>
+ * Intermediate accessors may be cached for reuse; however, retaining references to accessors can be expected to
+ * cause an increase in memory footprint so this should only be done in cases where there is a net gain in code
+ * simplicity or performance.  Some environments may have capability of inlining method calls in the chain and deleting
+ * short-lived allocations; retaining intermediate accessor references might defeat this capability leading to a
+ * degradation in overall performance for some specific workloads in such environments.
+ * <p>
+ * There are some constraints on the ways in which accessors may be derived.
+ * Accessors cannot retrieve values, provide type-specific defaults, or become optional unless the accessor has an
+ * associated type or converter.  Optional accessors cannot be used to create derived accessors with a different type
+ * or with type-specific defaults.  Accessors with a type-specific default value cannot be used to create
+ * derived accessors with a different type.
+ * <p>
+ * Accessor instances are serializable if (and only if) the associated configuration, the associated converter (if any),
+ * and the associated type-safe default value (if any) are <em>all</em> serializable.
+ * <p>
+ * Accessor instances are not required to cache configuration values.  As such, if the value is needed at multiple
+ * points in time, the result of {@link #getValue()} should generally be stored someplace for reuse.
+ *
+ * @param <T> the type of value being accessed
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
+ * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
+ * @author <a href="mailto:tomas.langer@oracle.com">Tomas Langer</a>
+ */
+public interface ConfigAccessor<T> {
+
+    /**
+     * Get the associated configuration value.
+     *
+     * @return the configuration value
+     *
+     * @throws IllegalArgumentException if the conversion of the value or a string default value failed
+     * @throws NoSuchElementException if the configuration value converts to an empty value, or the
+     *      configuration value is not given and no default value is set, or the configuration value is not given
+     *      and a string default value was set which converts to an empty value
+     * @throws IllegalStateException if the accessor is not associated with a type or converter
+     */
+    T getValue() throws IllegalArgumentException, NoSuchElementException, IllegalStateException;
+
+    /**
+     * Get the property name associated with this accessor.
+     *
+     * @return the property name
+     */
+    String getPropertyName();
+
+    /**
+     * Get the configuration that this accessor is derived from.
+     *
+     * @return the configuration that this accessor is derived from
+     */
+    Config getConfig();
+
+    /**
+     * Get a derived accessor which is configured identically to this accessor, but which references a different
+     * property name.
+     *
+     * @param propertyName the new property name (must not be {@code null})
+     * @return the derived accessor
+     */
+    ConfigAccessor<T> forPropertyName(String propertyName);
+
+    /**
+     * Get a derived accessor which returns an optional value.  The resultant accessor cannot be used to derive
+     * accessors with a different type or converter, or type-specific default value.
+     *
+     * @return the derived accessor
+     * @throws IllegalStateException if the accessor is already optional, or if a type or converter is not
+     *      associated with this accessor
+     */
+    ConfigAccessor<Optional<T>> optional() throws IllegalStateException;
+
+    /**
+     * Get a derived accessor which yields values converted by the given converter.  If this method is called on
+     * an accessor that is already associated with a type or converter, the previous type or converter is discarded
+     * and the new accessor will not reference it.
+     *
+     * @param converter the converter to use (must not be {@code null})
+     * @param <U> the target type
+     * @return the derived accessor
+     * @throws IllegalStateException if the accessor is optional, or if the accessor is already associated with a
+     *      type-specific default value
+     */
+    <U> ConfigAccessor<U> convertedWith(Converter<U> converter) throws IllegalStateException;
+
+    /**
+     * Get a derived accessor which yields values converted by the default converter for the given type.  If this method
+     * is called on an accessor that is already associated with a type or converter, the previous type or converter is
+     * discarded and the new accessor will not reference it.
+     *
+     * @param clazz the type of the value to return (must not be {@code null})
+     * @param <U> the target type
+     * @return the derived accessor
+     * @throws IllegalStateException if the accessor is optional, or if the accessor is already associated with a
+     *      type-specific default value, or if there is no converter available for the given type
+     */
+    <U> ConfigAccessor<U> convertedForType(Class<U> clazz) throws IllegalStateException;
+
+    /**
+     * Get a derived accessor which returns the given default value if the property is not found.  Any default value
+     * set on this accessor will not be referenced or known by the derived accessor.
+     * <p>
+     * Type-safe default
+     * values cannot be provided to optional accessors; to get an optional accessor with a type-safe default value,
+     * the default value should be set first.
+     *
+     * @param defaultValue the type-specific default value
+     * @return the derived accessor
+     * @throws IllegalStateException if the accessor is not associated with a type or a converter, or if the accessor
+     *      is optional
+     */
+    ConfigAccessor<T> withDefault(T defaultValue) throws IllegalStateException;
+
+    /**
+     * Get a derived accessor which returns the given default value if the property is not found.  Any default value
+     * set on this accessor will not be referenced or known by the derived accessor.  The default value is converted
+     * only if the property is not found.
+     * <p>
+     * Unlike {@link #withDefault(Object) withDefault(T)}, this method may be called on optional accessors as well as
+     * accessors which are not yet associated with a type or converter.
+     *
+     * @param defaultValue the type-specific default value (must not be {@code null})
+     * @return the derived accessor
+     */
+    ConfigAccessor<T> withStringDefault(String defaultValue);
+
+    /**
+     * Get a derived accessor which does not return a default value when a property is not found.  Any default value
+     * set on this accessor will not be referenced or known by the derived accessor.
+     *
+     * @return the derived accessor
+     */
+    ConfigAccessor<T> withoutDefault();
+}

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
@@ -1,6 +1,6 @@
 /*
  ********************************************************************************
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -24,6 +24,8 @@
  *      JavaDoc + priority
  *   2016-12-01 - Emily Jiang / IBM Corp
  *      Marking as FunctionalInterface + JavaDoc + additional types
+ *   2019-07-25 - David M. Lloyd
+ *      JavaDoc cleanups and clarification around empty value handling
  *
  *******************************************************************************/
 
@@ -31,80 +33,96 @@ package org.eclipse.microprofile.config.spi;
 
 /**
  * <p>Interface for converting configured values from String to any Java type.
- **
- * <p>Converters for the following types are provided by default:
- * <ul>
- *     <li>{@code boolean} and {@code Boolean}, values for {@code true}: (case insensitive)
- *     &quot;true&quot;, &quot;yes&quot;, &quot;Y&quot;, &quot;on&quot;, &quot;1&quot;</li>
- *     <li>{@code int} and {@code Integer}</li>
- *     <li>{@code long} and {@code Long}</li>
- *     <li>{@code float} and {@code Float}, a dot '.' is used to separate the fractional digits</li>
- *     <li>{@code double} and {@code Double}, a dot '.' is used to separate the fractional digits</li>
- *     <li>{@code java.lang.Class} based on the result of {@link java.lang.Class#forName}</li>
  *
+ * <h3>Global Converters</h3>
+ *
+ * Converters may be global to a {@code Config} instance.  Global converters are automatically applied to types that
+ * match the converter's type.
+ *
+ * <p>Global converters may be <em>built in</em>.  Such converters are provided by the implementation.  A compliant
+ * implementation must provide built-in converters for at least the following types:
+ * <ul>
+ *     <li>{@code boolean} and {@code Boolean}, returning {@code true} for at least the following values (case insensitive):
+ *     <ul>
+ *         <li>{@code true}</li>
+ *         <li>{@code yes}</li>
+ *         <li>{@code y}</li>
+ *         <li>{@code on}</li>
+ *         <li>{@code 1}</li>
+ *     </ul>
+ *     <li>{@code int} and {@code Integer}, accepting (at minimum) all values accepted by the {@link Integer#parseInt(String)} method</li>
+ *     <li>{@code long} and {@code Long}, accepting (at minimum) all values accepted by the {@link Long#parseLong(String)} method</li>
+ *     <li>{@code float} and {@code Float}, accepting (at minimum) all values accepted by the {@link Float#parseFloat(String)} method</li>
+ *     <li>{@code double} and {@code Double}, accepting (at minimum) all values accepted by the {@link Double#parseDouble(String)} method</li>
+ *     <li>{@code java.lang.Class} based on the result of {@link java.lang.Class#forName}</li>
+ *     <li>{@code java.lang.String}</li>
  * </ul>
  *
- * <p>Custom Converters will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
- * providing a file<br>
- * <code>META-INF/services/org.eclipse.microprofile.config.spi.Converter</code><br>
- * which contains the fully qualified {@code Converter} implementation class name as content.
+ * <p>Custom global converters will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
+ * providing a file named {@code META-INF/services/org.eclipse.microprofile.config.spi.Converter}
+ * which contains one or more fully qualified {@code Converter} implementation class names as content.
  *
- * <p>A Converter can specify a {@code javax.annotation.Priority}.
+ * <p>A custom global {@code Converter} implementation class may specify a {@code javax.annotation.Priority}.
  * If no priority is explicitly assigned, the value of 100 is assumed.
  * If multiple Converters are registered for the same type, the one with the highest priority will be used. Highest number means highest priority.
  *
- * <p>Custom Converters can also be registered programmatically via `ConfigBuilder#withConverters(Converter... converters)` or
- * `ConfigBuilder#withConverter(Class type, int priority, Converter converter)`.
+ * <p>Custom global converters may also be registered programmatically to a configuration builder via the
+ * {@link ConfigBuilder#withConverters(Converter[])} or {@link ConfigBuilder#withConverter(Class, int, Converter)} methods.
  *
- * All Built In Converters have a {@code javax.annotation.Priority} of 1
+ * <p>All built in converters have a {@code javax.annotation.Priority} of 1.
  * A Converter should handle null values returning either null or a valid Object of the specified type.
  *
- * <h3>Array Converters</h3>
- *  The implementation must support the Array converter for each built-in converters and custom converters.
- *  The delimiter for the config value is ",". The escape character is "\".
- *  <code>e.g. myPets=dog,cat,dog\,cat </code>
- * <p>
- *  For the property injection, List and Set should be supported as well.
+ * <p>Converters may return {@code null}, indicating that the result of the conversion is an empty value.
  *
- *  <p>
- *  Usage:
- *  <p>
- *  <code>
- *  String[] myPets = config.getValue("myPet", String[].class);
- *  </code>
- *
- *  <p>
- *  {@code @Inject @ConfigProperty(name="myPets") private String[] myPets;}
- *  <p>
- *  {@code @Inject @ConfigProperty(name="myPets") private List<String> myPets;}
- *
- *  <p>
- *  {@code @Inject @ConfigProperty(name="myPets") private Set<String> myPets;}
- *  <p>
- *  myPets will be "dog", "cat", "dog,cat"
  * <h3>Implicit Converters</h3>
  *
- * <p>If no explicit Converter and no built-in Converter could be found for a certain type,
- * the {@code Config} provides an <em>Implicit Converter</em>, if</p>
+ * <p>If no global converter could be found for a certain type,
+ * the {@code Config} implementation must provide an <em>Implicit Converter</em>, if:
  * <ul>
  *     <li>the target type {@code T} has a {@code public static T of(String)} method, or</li>
  *     <li>the target type {@code T} has a {@code public static T valueOf(String)} method, or</li>
- *     <li>the target type {@code T} has a public Constructor with a String parameter, or</li>
+ *     <li>the target type {@code T} has a public constructor with a {@code String} parameter, or</li>
  *     <li>the target type {@code T} has a {@code public static T parse(CharSequence)} method</li>
+ *     <li>the target type {@code T} is an array of any type that has an installed explicit, built-in, or implicit converter</li>
  * </ul>
-
+ *
+ * The implicit array converter uses a comma ({@code U+002C ','}) as a delimiter.  To allow a comma to be embedded within
+ * individual elements, it may be preceded by a backslash ({@code U+005C '\'}) character.  Any such escaped comma will be
+ * included within a single element (the backslash will be discarded).
+ * <p>
+ * The implicit array converter <em>must not</em> include empty segments within the conversion result.  An empty segment
+ * is defined as a segment for which the element converter has returned {@code null}.  If no elements are included, the
+ * value must be considered empty and {@code null} returned.
+ *
+ * <h3>Empty Values</h3>
+ *
+ * A {@code null} conversion result indicates that the converted value is empty.  All implicit converters defined
+ * here <em>must</em> return {@code null} when converting empty values.  All built-in global converters defined here
+ * <em>must</em> return {@code null} when converting empty values.  Other built-in global converters <em>should</em>
+ * return {@code null} when converting empty values.
+ * <p>
+ * Customized user converters and certain special built-in converters may return other values to represent empty.  However, this
+ * may be unexpected so the cases for such behavior should be clearly documented for each converter.
+ * <p>
+ * Most converters will consider an empty string value ({@code ""}) to be empty.  Some converters may yield an empty value
+ * for other inputs.
+ *
  * @author <a href="mailto:rsmeral@apache.org">Ron Smeral</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:john.d.ament@gmail.com">John D. Ament</a>
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public interface Converter<T> {
     /**
-     * Configure the string value to a specified type
-     * @param value the string representation of a property value.
-     * @return the converted value or null
+     * Configure the string value to a specified type.  If the given value string converts to an empty value,
+     * {@code null} may be returned to indicate that this is the case.  In particular, an empty input string
+     * should normally result in a {@code null} return value.
      *
-     * @throws IllegalArgumentException if the value cannot be converted to the specified type.
+     * @param value the string representation of a property value (must not be {@code null})
+     * @return the converted value or {@code null} if the result is an empty value
+     *
+     * @throws IllegalArgumentException if the value cannot be converted to the specified type
      */
     T convert(String value);
 }

--- a/spec/src/main/asciidoc/configexamples.asciidoc
+++ b/spec/src/main/asciidoc/configexamples.asciidoc
@@ -74,15 +74,14 @@ public class InjectedConfigUsageSample {
     @Inject
     private Config config;
 
-    //The property myprj.some.url must exist in one of the configsources, otherwise a
+    //The property myprj.some.url must have a non-empty value in one of the configsources, otherwise a
     //DeploymentException will be thrown.
     @Inject
     @ConfigProperty(name="myprj.some.url")
     private String someUrl;
-
-    //The following code injects an Optional value of myprj.some.port property.
+    //The following code injects a possibly empty value of myprj.some.port property.
     //Contrary to natively injecting the configured value this will not lead to a
-    //DeploymentException if the configured value is missing.
+    //DeploymentException if the configured value is empty.
     @Inject
     @ConfigProperty(name="myprj.some.port")
     private Optional<Integer> somePort;
@@ -90,16 +89,16 @@ public class InjectedConfigUsageSample {
     //Injects a Provider for the value of myprj.some.dynamic.timeout property to
     //resolve the property dynamically. Each invocation to Provider#get() will
     //resolve the latest value from underlying Config.
-    //The existence of configured values will get checked during startup.
+    //The validity of configured values will get checked during startup.
     //Instances of Provider<T> are guaranteed to be Serializable.
     @Inject
     @ConfigProperty(name="myprj.some.dynamic.timeout", defaultValue="100")
     private javax.inject.Provider<Long> timeout;
-    //Injects the value of the property myprj.name if specified in any of the configures, otherwise null will be injected. 
+    //Injects the value of the property myprj.name if specified in any of the configures, otherwise null will be injected.
     @Inject
     @ConfigProperty(name="myprj.name" defaultValue=ConfigProperty.NULL_VALUE)
     String name;
-    
+
     //The following code injects an Array, List or Set for the `myPets` property,
     //where its value is a comma separated value ( myPets=dog,cat,dog\\,cat)
     @Inject @ConfigProperty(name="myPets") private String[] myArrayPets;

--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -104,3 +104,50 @@ If no built-in nor custom `Converter` exists for a requested Type `T`, an implic
 
 If a `Converter` implements the `java.lang.AutoCloseable` interface  then the `close()` method will be called when the underlying `Config` is being released.
 
+=== Empty value
+
+A config property can be explicitly configured with an empty value (the empty String `""`).  If a property
+is missing and no default value exists for that property, it is considered to be empty.
+
+The `Config.getValue()` method will normally throw a `NoSuchElementException` when a configuration value
+is empty.  In order to allow empty values to be returned, either the `Config.getOptionalValue()`
+method must be used, or a custom converter must be specified which provides a specific value for
+the case where an empty value is returned (either implicitly due to the property being missing, or
+explicitly due to an empty value being specified for a configuration property).
+
+[NOTE]
+This behaviour allows users to _unconfigure_ a property. If a property is configured in a lower-ordinal ConfigSource with
+an undesirable value, you can set the property value to an empty string in a higher-ordinal ConfigSource to discard the lower-ordinal value.
+
+When processing array or collection values, any empty array or collection segments must be excluded from the
+resultant array or collection.
+
+[[empty_value_table]]
+.Examples of Config API behavior for empty values
+[options="header"]
+|=======================
+| Property value | Output type | `Config` method | Output result
+| missing     | `String` | `getValue` | throws `NoSuchElementException`
+| `""` (empty string) | `String` | `getValue` | throws `NoSuchElementException`
+| `" "`       | `String` | `getValue` | `" "`
+| `"foo"`     | `String`   | `getValue` |  `"foo"`
+| missing     | `String[]` | `getValue` | throws `NoSuchElementException`
+| `""`        | `String[]` | `getValue` | throws `NoSuchElementException`
+| `" "`       | `String[]` | `getValue` | `{ " " }`
+| `","`       | `String[]` | `getValue` | throws `NoSuchElementException`
+| `",,"`      | `String[]` | `getValue` | throws `NoSuchElementException`
+| `"foo"`     | `String[]` | `getValue` | `{ "foo" }`
+| `"foo,bar"` | `String[]` | `getValue` | `{ "foo", "bar" }`
+| `"foo,"`    | `String[]` | `getValue` | `{ "foo" }`
+| `",bar"`    | `String[]` | `getValue` | `{ "bar" }`
+| `",bar,"`   | `String[]` | `getValue` | `{ "bar" }`
+| missing     | `String` |`getOptionalValue` | `Optional.empty()`
+| `""`        | `String` | `getOptionalValue` | `Optional.empty()`
+| `" "`        | `String` | `getOptionalValue` | `Optional.of(" ")`
+| `"foo"`     | `String` | `getOptionalValue` | `Optional.of("foo")`
+| missing | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `""` | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `","` | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `",,"` | `String[]` | `getOptionalValue` | `Optional.empty()`
+| `"foo,bar"` | `String[]` | `getOptionalValue` | `Optional.of({ "foo", "bar" })`
+|=======================

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyBean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.config.tck;
+
+import static org.eclipse.microprofile.config.tck.EmptyConfigPropertyTest.EMPTY_PROP;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Dependent
+public class EmptyConfigPropertyBean {
+
+    @Inject
+    @ConfigProperty(name = EMPTY_PROP)
+    private String[] myStrings;
+
+    @Inject
+    @ConfigProperty(name = EMPTY_PROP)
+    private List<String> myStringList;
+
+    @Inject
+    @ConfigProperty(name = EMPTY_PROP)
+    private Set<String> myStringSet;
+
+    public String[] getMyStrings() {
+        return myStrings;
+    }
+
+    public List<String> getMyStringList() {
+        return myStringList;
+    }
+
+    public Set<String> getMyStringSet() {
+        return myStringSet;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyConfigPropertyTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.config.tck;
+
+import static org.eclipse.microprofile.config.tck.base.AbstractTest.addFile;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.tck.configsources.KeyValuesConfigSource;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class EmptyConfigPropertyTest  extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+            .create(JavaArchive.class, "EmptyConfigPropertyTest.jar")
+            .addClass(KeyValuesConfigSource.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+            .as(JavaArchive.class);
+
+        addFile(testJar, "META-INF/microprofile-config.properties");
+
+        WebArchive war = ShrinkWrap
+            .create(WebArchive.class, "EmptyConfigPropertyTest.war")
+            .addAsLibrary(testJar);
+        return war;
+    }
+
+
+    private @Inject
+    Config config;
+
+    static final String EMPTY_PROP = "tck.config.empty";
+    static final String MISSING_PROP = "tck.config.this.property.is.not.defined.anywhere";
+
+    @Test
+    public void testEmptyPropertyWithConfig() {
+        // | Property value | Output type | `Config` method | Output result
+        // | `""` (empty string) | `String` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(EMPTY_PROP, String.class);
+            Assert.fail("An empty string is considered as missing and must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        try {
+            config.getValue(EMPTY_PROP, Double.class);
+            Assert.fail(("an empty String is considered missing regardless of the output type"));
+        }
+        catch (NoSuchElementException e) {
+        }
+
+        // | `""`        | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(EMPTY_PROP, String[].class);
+            Assert.fail(("an empty String is considered missing regardless of the output type"));
+        }
+        catch (NoSuchElementException e) {
+        }
+        try {
+            config.getValue(EMPTY_PROP, Double[].class);
+            Assert.fail(("an empty String is considered missing regardless of the output type"));
+        }
+        catch (NoSuchElementException e) {
+        }
+
+
+        // | `""`        | `String` | `getOptionalValue` | `Optional.empty()`
+        assertEquals(config.getOptionalValue(EMPTY_PROP, String.class), Optional.empty());
+        assertEquals(config.getOptionalValue(EMPTY_PROP, Double.class), Optional.empty());
+
+        // | `""` | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals( config.getOptionalValue(EMPTY_PROP, String[].class), Optional.empty());
+        assertEquals( config.getOptionalValue(EMPTY_PROP, Double[].class), Optional.empty());
+    }
+
+    @Test
+    public void testMissingProperty() {
+        // | Property value | Output type | `Config` method | Output result
+        // | missing     | `String` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(MISSING_PROP, String.class);
+            Assert.fail("A missing property must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // | missing     | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue(MISSING_PROP, String[].class);
+            Assert.fail("A missing property must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // regardless of the output type
+        try {
+            config.getValue(MISSING_PROP, Double[].class);
+            Assert.fail("A missing property must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+
+        // | missing     | `String` |`getOptionalValue` | `Optional.empty()`
+        assertEquals( config.getOptionalValue(MISSING_PROP, String.class), Optional.empty());
+        // | missing | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals( config.getOptionalValue(MISSING_PROP, String[].class), Optional.empty());
+    }
+
+    @Test
+    public void testArrayCommasRules() {
+        Config config = KeyValuesConfigSource.buildConfig(
+            "arrayWithSpace", " ",
+            "arrayWithSingleComma", ",",
+            "arrayWithTwoCommas", ",,",
+            "arrayWithSingleValue", "foo",
+            "arrayWithTwoValues", "foo,bar",
+            "arrayWithTrailingComma", "foo,",
+            "arrayWithLeadingComma", ",bar",
+            "arrayWithLeadingAndTrailingCommas", ",bar,");
+
+        // | Property value | Output type | `Config` method | Output result
+        // | `" "`       | `String[]` | `getValue` | `{ " " }`
+        assertEquals(config.getValue("arrayWithSpace", String[].class), new String[] { " " });
+        // | `","`       | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue("arrayWithSingleComma", String[].class);
+            Assert.fail("An array with only empty elements must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // | `",,"`      | `String[]` | `getValue` | throws `NoSuchElementException`
+        try {
+            config.getValue("arrayWithTwoCommas", String[].class);
+            Assert.fail("An array with only empty elements must raise a NoSuchElementException");
+        }
+        catch (NoSuchElementException e) {
+        }
+        // | `"foo"`     | `String[]` | `getValue` | `{ "foo" }`
+        assertEquals(config.getValue("arrayWithSingleValue", String[].class), new String[] { "foo" });
+        // | `"foo,bar"` | `String[]` | `getValue` | `{ "foo", "bar" }`
+        assertEquals(config.getValue("arrayWithTwoValues", String[].class), new String[] { "foo", "bar" });
+        // | `"foo,"`    | `String[]` | `getValue` | `{ "foo" }`
+        assertEquals(config.getValue("arrayWithTrailingComma", String[].class), new String[] { "foo" });
+        // | `",bar"`    | `String[]` | `getValue` | `{ "bar" }`
+        assertEquals(config.getValue("arrayWithLeadingComma", String[].class), new String[] { "bar" });
+        // | `",bar,"`   | `String[]` | `getValue` | `{ "bar" }`
+        assertEquals(config.getValue("arrayWithLeadingAndTrailingCommas", String[].class), new String[] { "bar" });
+
+        // | `","` | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals(config.getOptionalValue("arrayWithSingleComma", String[].class), Optional.empty());
+        // | `",,"` | `String[]` | `getOptionalValue` | `Optional.empty()`
+        assertEquals(config.getOptionalValue("arrayWithTwoCommas", String[].class), Optional.empty());
+    }
+
+    @Test
+    public void testEmptyPropertyResetsLowerOrdinalProperty() {
+        Config config = ConfigProviderResolver.instance().getBuilder()
+            .withSources(
+                // lower-ordinal configures a prop
+                KeyValuesConfigSource.config(10,
+                    "my.prop", "foo"),
+                // higher-ordinal resets it with an empty string
+                KeyValuesConfigSource.config(20,
+                    "my.prop", ""))
+            .build();
+
+        try {
+            config.getValue("my.prop", String.class);
+            fail("The property must be reset by the empty string in the higher-ordinal config source");
+        }
+        catch (NoSuchElementException e) {
+        }
+
+        assertEquals(config.getOptionalValue("my.prop", String.class), Optional.empty());
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyValuesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/EmptyValuesTest.java
@@ -19,6 +19,12 @@
  */
 package org.eclipse.microprofile.config.tck;
 
+import static org.testng.Assert.assertEquals;
+
+import java.util.NoSuchElementException;
+
+import javax.inject.Inject;
+
 import org.eclipse.microprofile.config.Config;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -29,10 +35,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
-
-import javax.inject.Inject;
-
-import static org.testng.Assert.assertEquals;
 
 public class EmptyValuesTest extends Arquillian {
 
@@ -63,17 +65,30 @@ public class EmptyValuesTest extends Arquillian {
         assertEquals(emptyValuesBean.getStringValue(), "");
     }
 
-    @Test
+    @Test(expectedExceptions = NoSuchElementException.class)
     public void testEmptyStringProgrammaticLookup() {
-        System.setProperty(EMPTY_PROPERTY, "");
-        String stringValue = config.getValue(EMPTY_PROPERTY, String.class);
-        assertEquals(stringValue, "");
-        System.clearProperty(EMPTY_PROPERTY);
+        try {
+            System.setProperty(EMPTY_PROPERTY, "");
+            config.getValue(EMPTY_PROPERTY, String.class);
+        }
+        finally {
+            System.clearProperty(EMPTY_PROPERTY);
+        }
     }
 
-    @Test
+    @Test(expectedExceptions =  NoSuchElementException.class)
     public void testEmptyStringPropertyFromConfigFile() {
-        String stringValue = config.getValue(PROP_FILE_EMPTY_PROPERTY, String.class);
-        assertEquals(stringValue, "");
+        config.getValue(PROP_FILE_EMPTY_PROPERTY, String.class);
+    }
+
+    @Test(expectedExceptions = NoSuchElementException.class)
+    public void testEmptyStringLookupAsArray() {
+        try {
+            System.setProperty(EMPTY_PROPERTY, "");
+            config.getValue(EMPTY_PROPERTY, String[].class);
+        }
+        finally {
+            System.clearProperty(EMPTY_PROPERTY);
+        }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/KeyValuesConfigSource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/KeyValuesConfigSource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.config.tck.configsources;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class KeyValuesConfigSource implements ConfigSource {
+
+
+    private final Map<String, String> properties = new HashMap<>();
+    private final int ordinal;
+
+    private KeyValuesConfigSource(Map<String, String> properties, int ordinal) {
+        this.properties.putAll(properties);
+        this.ordinal = ordinal;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return properties.get(propertyName);
+    }
+
+    @Override
+    public int getOrdinal() {
+        return ordinal;
+    }
+
+    @Override
+    public String getName() {
+        return "KeyValuesConfigSource";
+    }
+
+    public static ConfigSource config(String... keyValues) {
+        return config(DEFAULT_ORDINAL, keyValues);
+    }
+
+    public static ConfigSource config(int ordinal, String... keyValues) {
+        if (keyValues.length %2 != 0) {
+            throw new IllegalArgumentException("keyValues array must be a multiple of 2");
+        }
+
+        Map<String, String> props = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            props.put(keyValues[i], keyValues[i+1]);
+        }
+        return new KeyValuesConfigSource(props, ordinal);
+    }
+
+    public static Config buildConfig(String... keyValues) {
+        return ConfigProviderResolver.instance().getBuilder()
+            .withSources(KeyValuesConfigSource.config(keyValues))
+            .build();
+    }
+}

--- a/tck/src/main/resources/internal/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/internal/META-INF/microprofile-config.properties
@@ -155,3 +155,6 @@ tck.config.test.javaconfig.converter.urlvalues=http://microprofile.io,http://ope
 
 tck.config.test.javaconfig.converter.class=org.eclipse.microprofile.config.tck.ClassConverterTest
 tck.config.test.javaconfig.converter.class.array=org.eclipse.microprofile.config.tck.ClassConverterTest,java.lang.String
+
+# empty config property test
+tck.config.empty=


### PR DESCRIPTION
This is the second option for an API to support the new consistent rules for empty value handling, by creating a fluent accessor API instead of using method overloads.  Supercedes #407.  Fixes #446.