### PR TITLE
Add tests for obtaining arrays over getOptionalValue

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ArrayConverterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ArrayConverterTest.java
@@ -33,6 +33,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -90,6 +91,17 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalBooleanLookupProgrammatically() {
+        Optional<Boolean[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.booleanvalues",
+            Boolean[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Boolean[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 3);
+        Assert.assertEquals(value, new Boolean[]{true, false, true});
+    }    
+
+    @Test
     public void testBooleanArrayInjection() {
         Assert.assertEquals(converterBean.getMyBooleans().length, 3);
         Assert.assertEquals(converterBean.getMyBooleans(), new Boolean[]{true, false, true});
@@ -127,6 +139,17 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalStringLookupProgrammatically() {
+        Optional<String[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.stringvalues",
+            String[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        String[] value = optionalValue.get();        
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 4);
+        Assert.assertEquals(value, new String[]{"microservice", "microprofile", "m,f", "microservice"});
+    }    
+
+    @Test
     public void testStringArrayInjection() {
         Assert.assertEquals(converterBean.getMyStrings().length, 4);
         Assert.assertEquals(converterBean.getMyStrings(), new String[]{"microservice", "microprofile", "m,f", "microservice"});
@@ -157,6 +180,17 @@ public class ArrayConverterTest extends Arquillian {
         Assert.assertEquals(value.length, 2);
         Assert.assertEquals(value, new Integer[]{1234, 9999});
     }
+
+    @Test
+    public void testOptionalIntLookupProgrammatically() {
+        Optional<Integer[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.integervalues",
+            Integer[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Integer[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals(value, new Integer[]{1234, 9999});
+    }    
 
     @Test
     public void testIntArrayInjection() {
@@ -198,6 +232,17 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalLongLookupProgrammatically() {
+        Optional<Long[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.longvalues",
+            Long[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Long[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals(value, new Long[] {1234567890L, 1999999999L});
+    }    
+
+    @Test
     public void testLongArrayInjection() {
         Assert.assertEquals(converterBean.getMyLongs().length, 2);
         Assert.assertEquals(converterBean.getMyLongs(), new Long[] {1234567890L, 1999999999L});
@@ -235,6 +280,17 @@ public class ArrayConverterTest extends Arquillian {
         Assert.assertEquals(value.length, 2);
         Assert.assertEquals(value, new Float[]{12.34f, 99.99f});
     }
+
+    @Test
+    public void testOptionalFloatLookupProgrammatically() {
+        Optional<Float[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.floatvalues",
+            Float[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Float[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals(value, new Float[]{12.34f, 99.99f});
+    }    
 
     @Test
     public void testFloatArrayInjection() {
@@ -276,6 +332,17 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalDoubleLookupProgrammatically() {
+        Optional<Double[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.doublevalues",
+            Double[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Double[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals( value, new Double[]{12.34d,99.9999d});
+    }    
+
+    @Test
     public void testDoubleArrayInjection() {
         Assert.assertEquals(converterBean.getMyDoubles().length, 2);
         Assert.assertEquals( converterBean.getMyDoubles(), new Double[]{12.34d,99.9999d});
@@ -289,7 +356,7 @@ public class ArrayConverterTest extends Arquillian {
         Assert.assertEquals( converterBean.getMydoubles(), new double[]{12.34d,99.9999d});
     }
 
-        @Test
+    @Test
     public void testDoubleListInjection() {
         Assert.assertEquals(converterBean.getMyDoubleList().size(), 2);
         Assert.assertEquals(converterBean.getMyDoubleList(), Arrays.asList(12.34d,99.9999d));
@@ -315,6 +382,19 @@ public class ArrayConverterTest extends Arquillian {
             Duration.parse("PT15M"),
             Duration.parse("PT20M")});
     }
+
+    @Test
+    public void testOptionalDurationLookupProgrammatically() {
+        Optional<Duration[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.durationvalues",
+            Duration[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Duration[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals( value, new Duration[]{
+            Duration.parse("PT15M"),
+            Duration.parse("PT20M")});
+    }    
 
     @Test
     public void testDurationArrayInjection() {
@@ -356,6 +436,19 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalLocalTimeLookupProgrammatically() {
+        Optional<LocalTime[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.localtimevalues",
+            LocalTime[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        LocalTime[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals( value, new LocalTime[]{
+            LocalTime.parse("10:37"),
+            LocalTime.parse("11:44")});
+    }    
+
+    @Test
     public void testLocalTimeArrayInjection() {
         Assert.assertEquals(converterBean.getMyLocaltimes().length, 2);
         Assert.assertEquals(converterBean.getMyLocaltimes(), new LocalTime[]{
@@ -392,6 +485,19 @@ public class ArrayConverterTest extends Arquillian {
             LocalDate.parse("2017-12-24"),
             LocalDate.parse("2017-11-29")});
     }
+
+    @Test
+    public void testOptionalLocalDateLookupProgrammatically() {
+        Optional<LocalDate[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.localdatevalues",
+            LocalDate[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        LocalDate[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals(value, new LocalDate[]{
+            LocalDate.parse("2017-12-24"),
+            LocalDate.parse("2017-11-29")});
+    }    
 
     @Test
     public void testLocalDateArrayInjection() {
@@ -432,6 +538,19 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalLocalDateTimeLookupProgrammatically() {
+        Optional<LocalDateTime[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.localdatetimevalues",
+             LocalDateTime[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        LocalDateTime[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals( value, new LocalDateTime[]{
+            LocalDateTime.parse("2017-12-24T10:25:30"),
+            LocalDateTime.parse("2017-12-24T10:25:33")});
+    }    
+
+    @Test
     public void testLocalDateTimeArrayInjection() {
         Assert.assertEquals(converterBean.getMyLocalDateTimes().length, 2);
         Assert.assertEquals(converterBean.getMyLocalDateTimes(), new LocalDateTime[]{
@@ -468,6 +587,19 @@ public class ArrayConverterTest extends Arquillian {
             OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
             OffsetDateTime.parse("2007-12-03T10:15:30+02:00")});
     }
+
+    @Test
+    public void testOptionalOffsetDateTimeLookupProgrammatically() {
+        Optional<OffsetDateTime[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.offsetdatetimevalues",
+                OffsetDateTime[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        OffsetDateTime[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals( value, new OffsetDateTime[] {
+            OffsetDateTime.parse("2007-12-03T10:15:30+01:00"),
+            OffsetDateTime.parse("2007-12-03T10:15:30+02:00")});
+    }    
 
     @Test
     public void testOffsetDateTimeArrayInjection() {
@@ -509,6 +641,19 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalOffsetTimeLookupProgrammatically() {
+        Optional<OffsetTime[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.offsettimevalues",
+              OffsetTime[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        OffsetTime[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals( value, new OffsetTime[]{
+            OffsetTime.parse("13:45:30.123456789+02:00"),
+            OffsetTime.parse("13:45:30.123456789+03:00")});
+    }    
+
+    @Test
     public void testOffsetTimeArrayInjection() {
         Assert.assertEquals(converterBean.getMyOffsetTimes().length, 2);
         Assert.assertEquals(converterBean.getMyOffsetTimes(), new OffsetTime[]{
@@ -546,6 +691,19 @@ public class ArrayConverterTest extends Arquillian {
             Instant.parse("2015-06-02T21:34:33.616Z"),
             Instant.parse("2017-06-02T21:34:33.616Z")});
     }
+
+    @Test
+    public void testOptionalInstantLookupProgrammatically() {
+        Optional<Instant[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.instantvalues",
+               Instant[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Instant[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 2);
+        Assert.assertEquals(value,  new Instant[]{
+            Instant.parse("2015-06-02T21:34:33.616Z"),
+            Instant.parse("2017-06-02T21:34:33.616Z")});
+    }    
 
     @Test
     public void testInstantArrayInjection() {
@@ -587,6 +745,20 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalUrlLookupProgrammatically() throws MalformedURLException {
+        Optional<URL[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.urlvalues", URL[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        URL[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 3);
+        Assert.assertEquals(value, new URL[]{
+            new URL("http://microprofile.io"),
+            new URL("http://openliberty.io"),
+            new URL("http://microprofile.io")});
+    }
+
+
+    @Test
     public void testUrlArrayInjection() throws MalformedURLException {
         Assert.assertEquals(converterBean.getMyUrls().length, 3);
         Assert.assertEquals(converterBean.getMyUrls(), new URL[]{
@@ -626,6 +798,19 @@ public class ArrayConverterTest extends Arquillian {
     }
 
     @Test
+    public void testOptionalUriLookupProgrammatically() {
+        Optional<URI[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.urlvalues", URI[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        URI[] value = optionalValue.get();
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 3);
+        Assert.assertEquals(value, new URI[]{
+            URI.create("http://microprofile.io"),
+            URI.create("http://openliberty.io"),
+            URI.create("http://microprofile.io")});
+    }    
+
+    @Test
     public void testUriArrayInjection() {
         Assert.assertEquals(converterBean.getMyUris().length, 3);
         Assert.assertEquals(converterBean.getMyUris(), new URI[]{
@@ -660,6 +845,20 @@ public class ArrayConverterTest extends Arquillian {
     public void testCustomTypeArrayLookupProgrammatically() {
         Pizza[] value = config.getValue("tck.config.test.javaconfig.converter.array.pizza",
             Pizza[].class);
+        Assert.assertNotNull(value);
+        Assert.assertEquals(value.length, 3);
+        Assert.assertEquals(value, new Pizza[]{
+            new Pizza("cheese,mushroom", "large"),
+            new Pizza("chicken", "medium"),
+            new Pizza("pepperoni", "small")});
+    }
+
+    @Test
+    public void testOptionalCustomTypeArrayLookupProgrammatically() {
+        Optional<Pizza[]> optionalValue = config.getOptionalValue("tck.config.test.javaconfig.converter.array.pizza",
+            Pizza[].class);
+        Assert.assertTrue(optionalValue.isPresent());
+        Pizza[] value = optionalValue.get();
         Assert.assertNotNull(value);
         Assert.assertEquals(value.length, 3);
         Assert.assertEquals(value, new Pizza[]{


### PR DESCRIPTION
`ArrayConverterTest` was missing tests for programmatic lookup over `Config.getOptionalValue(String, Class)`, new testcase with optional was added for every programmatic testcase.