### PR TITLE
Adjust documentation on Config interface

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -60,7 +60,7 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  * <pre>
  * public void doSomething(
  *   Config cfg = ConfigProvider.getConfig();
- *   String archiveUrl = cfg.getString("my.project.archive.endpoint", String.class);
+ *   String archiveUrl = cfg.getValue("my.project.archive.endpoint", String.class);
  *   Integer archivePort = cfg.getValue("my.project.archive.port", Integer.class);
  * </pre>
  *


### PR DESCRIPTION
The API documentation has a typo in which a non-existent `Config::getString` method is mentioned in an example. This PR fixes that.

The incorrect example can be seen in the current [documentation for the Config interface](https://javadoc.io/static/org.eclipse.microprofile.config/microprofile-config-api/1.3/org/eclipse/microprofile/config/Config.html).