### PR TITLE
Set explicit version of plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
             <plugin>
                 <groupId>org.eclipse.microprofile.maven</groupId>
                 <artifactId>microprofile-maven-build-extension</artifactId>
+                <version>1.0</version>
                 <extensions>true</extensions>
             </plugin>
 


### PR DESCRIPTION
To avoid:
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.eclipse.microprofile.config:microprofile-config-api:jar:1.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.eclipse.microprofile.maven:microprofile-maven-build-extension is missing. @ org.eclipse.microprofile.config:microprofile-config-parent:1.4-SNAPSHOT, .../pom.xml, line 191, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.eclipse.microprofile.config:microprofile-config-tck:jar:1.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.eclipse.microprofile.maven:microprofile-maven-build-extension is missing. @ org.eclipse.microprofile.config:microprofile-config-parent:1.4-SNAPSHOT, .../pom.xml, line 191, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.eclipse.microprofile.config:microprofile-config-spec:pom:1.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.eclipse.microprofile.maven:microprofile-maven-build-extension is missing. @ org.eclipse.microprofile.config:microprofile-config-parent:1.4-SNAPSHOT, .../pom.xml, line 191, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.eclipse.microprofile.config:microprofile-config-parent:pom:1.4-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.eclipse.microprofile.maven:microprofile-maven-build-extension is missing. @ line 191, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```