### PR TITLE
Major JavaDoc cleanups, including grammar, structure, style, and content improvements

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -89,48 +89,59 @@ public interface Config {
 
     /**
      * Return the resolved property value with the specified type for the
-     * specified property name from the underlying {@link ConfigSource ConfigSources}.
-     *
-     * If this method gets used very often then consider to locally store the configured value.
+     * specified property name from the underlying {@linkplain ConfigSource configuration sources}.
+     * <p>
+     * The configuration value is not guaranteed to be cached by the implementation, and may be expensive
+     * to compute; therefore, if the returned value is intended to be frequently used, callers should consider storing
+     * rather than recomputing it.
      *
      * @param <T>
      *             The property type
      * @param propertyName
-     *             The configuration propertyName.
+     *             The configuration property name
      * @param propertyType
-     *             The type into which the resolve property value should get converted
-     * @return the resolved property value as an object of the requested type.
-     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
-     * @throws java.util.NoSuchElementException if the property isn't present in the configuration.
+     *             The type into which the resolved property value should get converted
+     * @return the resolved property value as an instance of the requested type
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration
      */
     <T> T getValue(String propertyName, Class<T> propertyType);
 
     /**
      * Return the resolved property value with the specified type for the
-     * specified property name from the underlying {@link ConfigSource ConfigSources}.
+     * specified property name from the underlying {@linkplain ConfigSource configuration sources}.
+     * <p>
+     * The configuration value is not guaranteed to be cached by the implementation, and may be expensive
+     * to compute; therefore, if the returned value is intended to be frequently used, callers should consider storing
+     * rather than recomputing it.
      *
      * If this method is used very often then consider to locally store the configured value.
      *
      * @param <T>
      *             The property type
      * @param propertyName
-     *             The configuration propertyName.
+     *             The configuration property name
      * @param propertyType
-     *             The type into which the resolve property value should be converted
-     * @return The resolved property value as an Optional of the requested type.
+     *             The type into which the resolved property value should be converted
+     * @return The resolved property value as an {@code Optional} wrapping the requested type
      *
-     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type.
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
      */
     <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType);
 
     /**
-     * Return all property names used in any of the underlying {@link ConfigSource ConfigSources}.
+     * Return all property names returned by any of the underlying {@linkplain ConfigSource configuration sources}.
+     * The order of the returned property names is unspecified.
+     *
      * @return the names of all configured keys of the underlying configuration.
      */
     Iterable<String> getPropertyNames();
 
     /**
-     * @return all currently registered {@link ConfigSource ConfigSources} sorted by descending ordinal and ConfigSource name
+     * Return all of the currently registered {@linkplain ConfigSource configuration sources} for this configuration.
+     * The returned sources will be sorted by descending ordinal value and name.
+     *
+     * @return the configuration sources
      */
     Iterable<ConfigSource> getConfigSources();
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/ConfigProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/ConfigProvider.java
@@ -36,25 +36,26 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 /**
  * <p>
  * This is the central class to access a {@link Config}.
- * A {@link Config} provides access to application Configuration.
- * That might be auto-discovered {@code Config} or even manually created one.
+ * A {@link Config} provides access to the application's configuration.
+ * It may have been automatically discovered, or manually created and registered.
  *
  * <p>
  * The default usage is to use {@link #getConfig()} to automatically pick up the
- * 'Configuration' for the Thread Context ClassLoader (See
- * {@link Thread#getContextClassLoader()}).
+ * <em>configuration</em> for the current thread's {@linkplain Thread#getContextClassLoader() context class loader}.
  *
  * <p>
- * A 'Configuration' consists of the information collected from the registered {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources}.
- * These {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources} get sorted according to
- * their <em>ordinal</em> defined via {@link org.eclipse.microprofile.config.spi.ConfigSource#getOrdinal()}.
- * Thus it is possible to overwrite configuration by providing in a ConfigSource with higher importance from outside.
+ * A <em>configuration</em> consists of information collected from the registered
+ * <em>{@linkplain org.eclipse.microprofile.config.spi.ConfigSource configuration sources}</em>, combined with the set of
+ * registered {@linkplain org.eclipse.microprofile.config.spi.Converter converters}.
+ * The <em>configuration sources</em> get sorted according to their
+ * <em>{@linkplain org.eclipse.microprofile.config.spi.ConfigSource#getOrdinal() ordinal value}</em>.
+ * Thus it is possible to override a lower-priority <em>configuration source</em> with a higher-priority one.
  *
  * <p>
- * It is also possible to register custom {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources} to flexibly
- * extend the configuration mechanism. An example would be to pick up
+ * It is also possible to register custom <em>configuration sources</em> to flexibly
+ * extend the configuration mechanism. For example, a configuration source could be provided which reads
  * configuration values from a database table.
- *
+ * <p>
  * Example usage:
  *
  * <pre>
@@ -62,7 +63,7 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
  * Integer port = ConfigProvider.getConfig().getValue(&quot;myproject.some.remote.service.port&quot;, Integer.class);
  * </pre>
  *
- * For more advanced use cases like e.g. registering a manually created {@link Config} please see
+ * For more advanced use cases (e.g. registering a manually created {@link Config} instance), please see
  * {@link ConfigProviderResolver#registerConfig(Config, ClassLoader)} and {@link ConfigProviderResolver#getBuilder()}.
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
@@ -76,30 +77,29 @@ public final class ConfigProvider {
     }
 
     /**
-     * Provide a {@link Config} based on all {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources} of the
-     * current Thread Context ClassLoader (TCCL)
-     * 
+     * Get the {@linkplain Config configuration} corresponding to the current application, as defined by the
+     * calling thread's {@linkplain Thread#getContextClassLoader() context class loader}.
      * <p>
-     * 
-     * The {@link Config} will be stored for future retrieval.
+     * The {@link Config} instance will be created and registered to the context class loader if no such configuration
+     * is already created and registered.
      * <p>
-     * There is exactly a single Config instance per ClassLoader
+     * Each class loader corresponds to exactly one configuration.
      *
-     * @return the config object for the thread context classloader
+     * @return the configuration instance for the thread context class loader
      */
     public static Config getConfig() {
         return ConfigProviderResolver.instance().getConfig();
     }
 
     /**
-     * Provide a {@link Config} based on all {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources} of the
-     * specified ClassLoader
-     *
+     * Get the {@linkplain Config configuration} for the application corresponding to the given class loader instance.
      * <p>
-     * There is exactly a single Config instance per ClassLoader
+     * The {@link Config} instance will be created and registered to the given class loader if no such configuration
+     * is already created and registered.
+     * <p>
+     * Each class loader corresponds to exactly one configuration.
      *
-     * @param cl the specified classloader
-     * @return the config for the specified classloader
+     * @return the configuration instance for the given class loader
      */
     public static Config getConfig(ClassLoader cl) {
         return ConfigProviderResolver.instance().getConfig(cl);

--- a/api/src/main/java/org/eclipse/microprofile/config/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/package-info.java
@@ -21,7 +21,7 @@
 /**
  * <p>Configuration for Java Microprofile
  *
- * <h2>Rational</h2>
+ * <h2>Rationale</h2>
  *
  * <p>For many project artifacts (e.g. WAR, EAR) it should be possible to build them only once
  * and then install them at different customers, stages, etc.
@@ -72,7 +72,7 @@
  *
  * @author <a href="emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
- * 
+ *
  */
 
 @org.osgi.annotation.versioning.Version("1.0.1")

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
@@ -31,7 +31,7 @@ package org.eclipse.microprofile.config.spi;
 import org.eclipse.microprofile.config.Config;
 
 /**
- * Builder for manually creating an instance of a {@code Config}.
+ * A builder for manually creating a configuration instance.
  *
  * @see ConfigProviderResolver#getBuilder()
  *
@@ -42,77 +42,83 @@ import org.eclipse.microprofile.config.Config;
 @org.osgi.annotation.versioning.ProviderType
 public interface ConfigBuilder {
     /**
-     * Add the default config sources appearing on the builder's classpath
-     * including:
-     * <ol>
-     * <li>System properties</li>
-     * <li>Environment properties</li>
-     * <li>/META-INF/microprofile-config.properties</li>
-     * </ol>
+     * Add the <a href="ConfigSource.html#default_config_sources"><em>default configuration sources</em></a>
+     * to the configuration being built.
      *
-     * @return the ConfigBuilder with the default config sources
+     * @return this configuration builder instance
      */
     ConfigBuilder addDefaultSources();
 
     /**
-     * Add the config sources appearing to be loaded via service loader pattern
+     * Add the all configuration sources which can be <a href="ConfigSource.html#discovery">discovered</a> from
+     * this configuration builder's {@linkplain #forClassLoader(ClassLoader) class loader}.
      *
-     * @return the ConfigBuilder with the autodiscovered config sources
+     * @return this configuration builder instance
      */
     ConfigBuilder addDiscoveredSources();
 
     /**
-     * Add the converters to be loaded via service loader pattern
+     * Add the all configuration converters which can be <a href="Converter.html#discovery">discovered</a> from
+     * this configuration builder's {@linkplain #forClassLoader(ClassLoader) class loader}.
      *
-     * @return the ConfigBuilder with the autodiscovered converters
+     * @return this configuration builder instance
      */
     ConfigBuilder addDiscoveredConverters();
+
     /**
-     * Return the ConfigBuilder for a given classloader
+     * Specify the class loader for which this configuration is being built.
      *
-     * @param loader the specified classloader
-     * @return the ConfigureBuilder for the given classloader
+     * @param loader the class loader
+     * @return this configuration builder instance
      */
     ConfigBuilder forClassLoader(ClassLoader loader);
 
     /**
-     * Add the specified {@link ConfigSource}.
+     * Add the specified {@link ConfigSource} instances to the configuration being built.
      *
-     * @param sources the config sources
-     * @return the ConfigBuilder with the configured sources
+     * @param sources the configuration sources
+     * @return this configuration builder instance
      */
     ConfigBuilder withSources(ConfigSource... sources);
 
     /**
-     * Add the specified {@link Converter}.
-     * This method uses reflection to determine what type the converter is for.
-     * When using lambda expressions for custom converters you should use
-     * {@link #withConverter(Class, int, Converter)} and pass the target type explicitly
-     * as lambda expressions do not offer enough type information to the reflection API.
+     * Add the specified {@link Converter} instances to the configuration being built.
+     * <p>
+     * The implementation may use reflection to determine the target type of the converter.  If the
+     * type cannot be determined reflectively, this method may fail with a runtime exception.
+     * <p>
+     * When using lambda expressions for custom converters you should use the
+     * {@link #withConverter(Class, int, Converter)} method and pass the target type explicitly,
+     * since lambda expressions generally do not offer enough type information to the reflection API
+     * in order to determine the target converter type.
+     * <p>
+     * The added converters will be given a priority of {@code 100}.
      *
-     * @param converters the converters
-     * @return the ConfigBuilder with the added converters
+     * @param converters the converters to add
+     * @return this configuration builder instance
      */
     ConfigBuilder withConverters(Converter<?>... converters);
 
-
     /**
-     * Add the specified {@link Converter} for the given type.
-     * This method does not rely on reflection to determine what type the converter is for
-     * therefore also lambda expressions can be used.
+     * Add the specified {@link Converter} instance for the given type to the configuration being built.
+     * <p>
+     * This method does not rely on reflection to determine the target type of the converter;
+     * therefore, lambda expressions may be used for the converter instance.
+     * <p>
+     * The priority value of custom converters is normally {@code 100}.
      *
-     * @param type the Class of type to convert
-     * @param priority the priority of the converter (custom converters have a default priority of 100).
+     * @param type the class of the type to convert
+     * @param priority the priority of the converter
      * @param converter the converter (can not be {@code null})
      * @param <T> the type to convert
-     * @return the ConfigBuilder with the added converters
+     * @return this configuration builder instance
      */
     <T> ConfigBuilder withConverter(Class<T> type, int priority, Converter<T> converter);
 
     /**
-     * Build the {@link Config} object.
+     * Build a new {@link Config} instance based on this builder instance.
      *
-     * @return the Config object
+     * @return the new configuration object
      */
     Config build();
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
@@ -32,102 +32,118 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * <p>Implement this interfaces to provide a ConfigSource.
- * A ConfigSource provides configuration values from a specific place, like JNDI configuration, a properties file, etc.
- * A ConfigSource is always read-only, any potential updates of the configured values must be handled directly inside each ConfigSource.
+ * A <em>configuration source</em> which provides configuration values from a specific place.  Some examples of configuration
+ * sources may include:
+ * <ul>
+ *     <li>a JNDI-backed naming service</li>
+ *     <li>a properties file</li>
+ *     <li>a database table</li>
+ * </ul>
+ * Implementations of this interface have the responsibility to get the value corresponding to a property name, and to
+ * enumerate available property names.
+ * <p>
+ * A <em>configuration source</em> is always read-only; any potential updates of the backing configuration values must be handled
+ * directly inside each configuration source instance.
  *
- * <p>The default config sources always available by default are:</p>
+ * <h3 id="default_config_sources">Default configuration sources</h3>
+ * Some configuration sources are known as <em>default configuration sources</em>.  These configuration sources are
+ * normally available in all automatically-created configurations, and can be
+ * {@linkplain ConfigBuilder#addDefaultSources() manually added} to manually-created configurations as well.  The
+ * default configuration sources are:
  * <ol>
- * <li>System properties (default ordinal=400)</li>
- * <li>Environment properties (default ordinal=300)
- * <li>/META-INF/microprofile-config.properties (ordinal=100)</li>
+ * <li>{@linkplain System#getProperties() System properties}, with an {@linkplain #getOrdinal() ordinal value} of {@code 400}</li>
+ * <li>{@linkplain System#getenv() Environment properties}, with an ordinal value of {@code 300}</li>
+ * <li>The {@code /META-INF/microprofile-config.properties} {@linkplain ClassLoader#getResource(String) resource}, with an ordinal value of {@code 100}</li>
  * </ol>
  *
- * <h3>Environment Variables Mapping Rules</h3>
- * <p>Some operating systems allow only alphabetic characters or an underscore, _, in environment variables.
- * Other characters such as ., /, etc may be disallowed. In order to set a value for a config property 
+ * <h3>Environment variable name mapping rules</h3>
+ *
+ * <p>Some operating systems allow only alphabetic characters or an underscore ({@code _}) in environment variable names.
+ * Other characters such as {@code .}, {@code /}, etc. may be disallowed. In order to set a value for a config property
  * that has a name containing such disallowed characters from an environment variable, the following rules are used.
- * This ConfigSource searches 3 environment variables for a given property name (e.g. {@code "com.ACME.size"}):</p>
+ * Three environment variables are searched for a given property name (e.g. "{@code com.ACME.size}"):
  *        <ol>
- *            <li>Exact match (i.e. {@code "com.ACME.size"})</li>
- *            <li>Replace each character that is neither alphanumeric nor _ with _ (i.e. {@code "com_ACME_size"})</li>
- *            <li>Replace each character that is neither alphanumeric nor _ with _ ; then convert the name to upper case
- * (i.e. {@code "COM_ACME_SIZE"})</li>
+ *            <li>The exact name (i.e. "{@code com.ACME.size}")</li>
+ *            <li>The name, with each character that is neither alphanumeric nor _ replaced with _ (i.e. "{@code com_ACME_size}")</li>
+ *            <li>The name, with each character that is neither alphanumeric nor _ replaced with _ and then converted to upper case
+ * (i.e. "{@code COM_ACME_SIZE}")</li>
  *        </ol>
- *    <p>The first environment variable that is found is returned by this ConfigSource.</p>
+ *    <p>The first of these environment variables that is found for a given name is returned.
  *
- * <p>Custom ConfigSource will get picked up via the {@link java.util.ServiceLoader} mechanism and and can be registered by
- * providing a file {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource}
- * which contains the fully qualified {@code ConfigSource} implementation class name as content.
+ * <h3 id="discovery">Configuration source discovery</h3>
  *
- * <p>Adding a dynamic amount of custom config sources can be done programmatically via
- * {@link org.eclipse.microprofile.config.spi.ConfigSourceProvider}.
+ * <p>Discovered configuration sources are loaded via the {@link java.util.ServiceLoader} mechanism and and can be registered by
+ * providing a resource named {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource},
+ * which contains the fully qualified {@code ConfigSource} implementation class name as its content.
  *
- *  <p>If a ConfigSource implements the {@link AutoCloseable} interface
- *  then the {@link AutoCloseable#close()} method will be called when
- *  the underlying {@link org.eclipse.microprofile.config.Config} is being released.
+ * <p>Configuration sources may also be added by defining
+ * {@link org.eclipse.microprofile.config.spi.ConfigSourceProvider} classes which are discoverable in this manner.
+ *
+ * <p>
+ * <h3>Closing configuration sources</h3>
+ *
+ * <p>If a configuration source implements the {@link AutoCloseable} interface,
+ * then its {@linkplain AutoCloseable#close() close method} will be called when
+ * the underlying configuration is released.
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:john.d.ament@gmail.com">John D. Ament</a>
- *
  */
 public interface ConfigSource {
+    /**
+     * The name of the default configuration ordinal property, "{@code config_ordinal}".
+     */
     String CONFIG_ORDINAL = "config_ordinal";
+
+    /**
+     * The default configuration ordinal value, {@code 100}.
+     */
     int DEFAULT_ORDINAL = 100;
 
     /**
-     * Return the properties in this config source
-     * @return the map containing the properties in this config source
+     * Return the properties in this configuration source as a map.
+     *
+     * @return a map containing properties of this configuration source
      */
     Map<String, String> getProperties();
 
     /**
-     * Gets all property names known to this config source, without evaluating the values. 
+     * Gets all property names known to this configuration source, without evaluating the values.
+     * <p>
+     * For backwards compatibility, there is a default implementation that just returns the keys of {@code getProperties()}.
+     * Implementations should consider replacing this with a more performant implementation.
+     * <p>
      * The returned property names may be a subset of the names of the total set of retrievable properties in this config source.
      *
-     * For backwards compatibility, there is a default implementation that just returns the keys of {@code getProperties()}
-     * slower ConfigSource implementations should replace this with a more performant implementation
-     *
-     * @return the set of property keys that are known to this ConfigSource
+     * @return a set of property names that are known to this configuration source
      */
     default Set<String> getPropertyNames() {
         return getProperties().keySet();
     }
 
     /**
-     * Return the ordinal for this config source. If a property is specified in multiple config sources, the value
-     * in the config source with the highest ordinal takes precedence.
-     * For the config sources with the same ordinal value, the config source names will
+     * Return the ordinal priority value of this configuration source.
+     * If a property is specified in multiple config sources, the value in the config source with the highest ordinal
+     * takes precedence.
+     * For configuration sources with the same ordinal value, the configuration source name will
      * be used for sorting according to string sorting criteria.
-     * Note that this property only gets evaluated during ConfigSource discovery.
-     *
-     * The default ordinals for the default config sources:
-     <ol>
-     * <li>System properties (ordinal=400)</li>
-     * <li>Environment properties (ordinal=300)
-     *    <p>Some operating systems allow only alphabetic characters or an underscore(_), in environment variables.
-     *    Other characters such as ., /, etc may be disallowed.
-     *    In order to set a value for a config property that has a name containing such disallowed characters from an environment variable,
-     *    the following rules are used.
-     *    This ConfigSource searches for potentially 3 environment variables with a given property name (e.g. {@code "com.ACME.size"}):</p>
-     *        <ol>
-     *            <li>Exact match (i.e. {@code "com.ACME.size"})</li>
-     *            <li>Replace the character that is neither alphanumeric nor '_' with '_' (i.e. {@code "com_ACME_size"})</li>
-     *            <li>Replace the character that is neither alphanumeric nor '_' with '_' and convert to upper case 
-     *            (i.e. {@code "COM_ACME_SIZE"})</li>
-     *        </ol>
-     *    <p>The first environment variable that is found is returned by this ConfigSource.</p>
-     * </li>
-     * <li>/META-INF/microprofile-config.properties (default ordinal=100)</li>
-     * </ol>
-     *
-     *
-     * Any ConfigSource part of an application will typically use an ordinal between 0 and 200.
-     * ConfigSource provided by the container or 'environment' typically use an ordinal higher than 200.
-     * A framework which intends have values overwritten by the application will use ordinals between 0 and 100.
-     * The property "config_ordinal" can be specified to override the default value.
+     * <p>
+     * Note that this method is only evaluated during the construction of the configuration, and does not affect
+     * the ordering of configuration sources within a configuration after that time.
+     * <p>
+     * The ordinal values for the default configuration sources can be found <a href="#default_config_sources">above</a>.
+     * <p>
+     * Any configuration source which is a part of an application will typically use an ordinal between 0 and 200.
+     * Configuration sources provided by the container or 'environment' typically use an ordinal higher than 200.
+     * A framework which intends have values overridden by the application will use ordinals between 0 and 100.
+     * <p>
+     * The default implementation of this method looks for a configuration property named "{@link #CONFIG_ORDINAL config_ordinal}"
+     * to determine the ordinal value for this configuration source.  If the property is not found, then the
+     * {@linkplain #DEFAULT_ORDINAL default ordinal value} is used.
+     * <p>
+     * This method may be overridden by configuration source implementations to provide a different behavior.
      *
      * @return the ordinal value
      */
@@ -145,16 +161,20 @@ public interface ConfigSource {
     }
 
     /**
-     * Return the value for the specified property in this config source.
+     * Return the value for the specified property in this configuration source.
+     *
      * @param propertyName the property name
-     * @return the property value
+     * @return the property value, or {@code null} if the property is not present
      */
     String getValue(String propertyName);
 
     /**
-     * The name of the config might be used for logging or analysis of configured values.
+     * The name of the configuration source.  The name might be used for logging or for analysis of configured values,
+     * and also may be used in {@linkplain #getOrdinal() ordering decisions}.
+     * <p>
+     * An example of a configuration source name is "{@code property-file mylocation/myprops.properties}".
      *
-     * @return the 'name' of the configuration source, e.g. 'property-file mylocation/myproperty.properties'
+     * @return the name of the configuration source
      */
     String getName();
 

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSourceProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSourceProvider.java
@@ -30,18 +30,16 @@
 package org.eclipse.microprofile.config.spi;
 
 /**
- * <p>Implement this interfaces to provide multiple ConfigSources.
- * This is e.g. needed if there are multiple property files of a given name on the classpath
- * but they are not all known at compile time.
- *
- * <p>If a single ConfigSource exists, then there is no need
- * to register it using a custom implementation of ConfigSourceProvider, it can be
- * registered directly as a {@link ConfigSource}.
- *
- * <p>A ConfigSourceProvider will get picked up via the
+ * A provider for <em>configuration source</em> instances.
+ * <p>
+ * Implementations of this interface may supply zero or more {@linkplain ConfigSource configuration source} instances
+ * for a given application (as defined by the application's {@link ClassLoader}).
+ * <p>
+ * Instances of this interface will be {@linkplain ConfigBuilder#addDiscoveredSources() discovered} via the
  * {@link java.util.ServiceLoader} mechanism and can be registered by providing a
- * {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider} file which contains
- * the fully qualified classname of the custom ConfigSourceProvider.
+ * {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider}
+ * {@linkplain ClassLoader#getResource(String) resource} which contains
+ * the fully qualified class name of the custom {@code ConfigSourceProvider} implementation.
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
@@ -51,11 +49,11 @@ package org.eclipse.microprofile.config.spi;
 public interface ConfigSourceProvider {
 
     /**
-     * Return the collection of {@link ConfigSource}s.
-     * For each e.g. property file, we return a single ConfigSource or an empty list if no ConfigSource exists.
+     * Return the {@link ConfigSource} instances that are provided by this provider.  An empty {@code Iterable} may
+     * be returned if no sources are to be provided.
      *
-     * @param forClassLoader the classloader which should be used if any is needed
-     * @return the {@link ConfigSource ConfigSources} to register within the {@link org.eclipse.microprofile.config.Config}.
+     * @param forClassLoader the class loader which should be used for discovery and resource loading purposes
+     * @return the {@link ConfigSource} instances to register to the configuration
      */
     Iterable<ConfigSource> getConfigSources(ClassLoader forClassLoader);
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/package-info.java
@@ -19,31 +19,16 @@
  *******************************************************************************/
 
 /**
- * <p>This package contains classes which are used to extend the standard functionality in a portable way.
- * <p>A user can provide own {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources} and
- * {@link org.eclipse.microprofile.config.spi.Converter Converters} to extend the information available in the Config.
+ * This package contains classes which are used to implement the configuration API, and to extend the standard
+ * configuration functionality in a portable way.
+ * <p>
+ * Users and frameworks may provide custom {@link org.eclipse.microprofile.config.spi.ConfigSource} and
+ * {@link org.eclipse.microprofile.config.spi.Converter} instances.  Configuration instances may be set up and created
+ * using the {@link org.eclipse.microprofile.config.spi.ConfigBuilder} API.
+ * <p>
+ * The package also contains the class {@link org.eclipse.microprofile.config.spi.ConfigProviderResolver},
+ * which is used to implement the specification itself.
  *
- * <p>The package also contains the class {@link org.eclipse.microprofile.config.spi.ConfigProviderResolver}
- * which is used to pick up the actual implementation.
- * <h2>Usage</h2>
- * <p>This is used to build up a builder and manually add {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources}..</p>
- *
- *
- * <ol>
- * <li>Create a builder:
- * <pre>ConfigProviderResolver resolver = ConfigProviderResolver.instance(); </pre>
- * <pre>ConfigBuilder builder = resolver.getBuilder();</pre>
- * </li>
- * <li>Add config sources and build:
- * <pre>
- * Config config = builder.addDefaultSources().withSources(mySource).withConverters(myConverter).build;
- * </pre>
- * </li>
- * <li>(optional)Manage the lifecycle of the config
- * <pre> resolver.registerConfig(config, classloader);</pre>
- * <pre> resolver.releaseConfig(config);</pre>
- * </li>
- * </ol>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  *


### PR DESCRIPTION
This works towards #447 and also will make it easier to specify #448, #426, etc.  No behavior changes are specified in this PR as it is meant purely to clean up the formatting and language, to make it easier for upcoming PRs to cleanly specify behavior changes as needed.