### PR TITLE
Fixed assertEquals for testImplicitConverterSquenceOfBeforeValueOf.

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ImplicitConverterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ImplicitConverterTest.java
@@ -131,7 +131,7 @@ public class ImplicitConverterTest extends Arquillian {
     @Test
     public void testImplicitConverterSquenceOfBeforeValueOf() {
         ConvTestSequenceOfBeforeValueOf value = config.getValue
-        ("tck.config.test.javaconfig.converter.implicit.sequence.ofBeforevalueOf",
+        ("tck.config.test.javaconfig.converter.implicit.sequence.ofBeforeValueOf",
         ConvTestSequenceOfBeforeValueOf.class);
         Assert.assertNotNull(value);
         Assert.assertEquals(value.getVal(), "ofBeforeValueOf");

--- a/tck/src/main/resources/internal/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/internal/META-INF/microprofile-config.properties
@@ -134,7 +134,7 @@ tck.config.test.javaconfig.converter.implicit.stringOf=stringOf
 tck.config.test.javaconfig.converter.implicit.charSequenceParse.yearmonth=2017-12
 tck.config.test.javaconfig.converter.implicit.enumValueOf=BAZ
 
-tck.config.test.javaconfig.converter.implicit.sequence.ofBeforevalueOf=ofBeforevalueOf
+tck.config.test.javaconfig.converter.implicit.sequence.ofBeforeValueOf=ofBeforeValueOf
 tck.config.test.javaconfig.converter.implicit.sequence.valueOfBeforeParse=valueOfBeforeParse
 tck.config.test.javaconfig.converter.implicit.sequence.parseBeforeConstructor=parseBeforeConstructor
 


### PR DESCRIPTION
Test was going to always fail due to mismatch between configured value and expected value in test.