### PR TITLE
Revert #388 pending further discussion

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
@@ -103,16 +103,6 @@ import javax.inject.Qualifier;
 public @interface ConfigProperty {
     String UNCONFIGURED_VALUE="org.eclipse.microprofile.config.configproperty.unconfigureddvalue";
     /**
-     * Provide a way to specify {@code null} value for a property.
-     * e.g. The following example is to set the default value of {@code my.port} to null if the property is not specified in any config sources.
-     * <pre>
-     * &#064;Inject
-     * &#064;ConfigProperty(name="my.port" defaultValue=ConfigProperty.NULL_VALUE)
-     * String value;
-     * </pre>
-     */
-    String NULL_VALUE="org.eclipse.microprofile.config.configproperty.nullvalue";
-    /**
      * The key of the config property used to look up the configuration value.
      * If it is not specified, it will be derived automatically as {@code <class_name>.<injection_point_name>},
      * where {@code injection_point_name} is the field name or parameter name,

--- a/api/src/main/java/org/eclipse/microprofile/config/inject/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/inject/package-info.java
@@ -44,6 +44,6 @@
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * 
  */
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.0")
 package org.eclipse.microprofile.config.inject;
 

--- a/spec/src/main/asciidoc/configexamples.asciidoc
+++ b/spec/src/main/asciidoc/configexamples.asciidoc
@@ -96,11 +96,6 @@ public class InjectedConfigUsageSample {
     @Inject
     @ConfigProperty(name="myprj.some.dynamic.timeout", defaultValue="100")
     private javax.inject.Provider<Long> timeout;
-    //Injects the value of the property myprj.name if specified in any of the configures, otherwise null will be injected. 
-    @Inject
-    @ConfigProperty(name="myprj.name" defaultValue=ConfigProperty.NULL_VALUE)
-    String name;
-    
     //The following code injects an Array, List or Set for the `myPets` property,
     //where its value is a comma separated value ( myPets=dog,cat,dog\\,cat)
     @Inject @ConfigProperty(name="myPets") private String[] myArrayPets;

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPlainInjectionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPlainInjectionTest.java
@@ -46,8 +46,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import junit.framework.Assert;
-
 /**
  * Test cases for CDI-based API that test retrieving values from the configuration.
  * The tests depend only on CDI 1.2.
@@ -97,8 +95,6 @@ public class CDIPlainInjectionTest extends Arquillian {
         assertThat(bean.characterProperty, is(equalTo(Character.valueOf('c'))));
 
         assertThat(bean.doublePropertyWithDefaultValue, is(closeTo(3.1415, 0.1)));
-        Assert.assertNull("The property my.not.configured.nullable.property should be null",
-                 ConfigProvider.getConfig().getOptionalValue("my.not.configured.nullable.property", String.class).orElse(null));
     }
 
     /*
@@ -130,8 +126,6 @@ public class CDIPlainInjectionTest extends Arquillian {
         assertThat(bean.doublePropertyWithDefaultValue, is(closeTo(
                 ConfigProvider.getConfig().getOptionalValue("my.not.configured.double.property", Double.class)
                         .orElse(3.1415), 0.1)));
-        Assert.assertNull("The injected field nullableConfigValue is not null", bean.nullableConfigValue);
-
     }
 
     @Test
@@ -257,10 +251,6 @@ public class CDIPlainInjectionTest extends Arquillian {
         @Inject
         @ConfigProperty(name="my.not.configured.double.property", defaultValue = "3.1415")
         private Double doublePropertyWithDefaultValue;
-        // the property is not configured in any ConfigSoources, so null will be used to set the filed
-        @Inject
-        @ConfigProperty(name="my.not.configured.nullable.property", defaultValue = ConfigProperty.NULL_VALUE)
-        private String nullableConfigValue;
 
     }
 


### PR DESCRIPTION
Revert #388.  This methodology of injecting `null` introduces inconsistencies with the base API:

* It becomes impossible to implement injectable default values with a config source
* It becomes impossible to support a default value with a nullable property
* It introduces another problem case with respect to empty values
* It introduces a problem where injection produces a different result that cannot be replicated on the base API

We need to solve this problem another way. `Optional` is the preferred mechanism, but if we must support nullability on injection, then we should have a separate annotation or annotation property which indicates that the value is optional and there should be an implicit `.orElse(null)`.