### PR TITLE
Clarify behaviour of converters for primitive wrappers.

### DIFF
--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -48,7 +48,7 @@ All built-in ``Converter``s have the `@Priority` of `1`.
 === Adding custom Converters
 
 A custom `Converter` must implement the generic interface `org.eclipse.microprofile.config.spi.Converter`.
-The Type parameter of the interface is the target type the String is converted to.
+The Type parameter of the interface is the target type the String is converted to. If your converter targets a wrapper of a primitive type (e.g. `java.lang.Integer`), the converter applys to both the wrapper type and the primitive type (e.g `int`)
 You have to register your implementation in a file `/META-INF/services/org.eclipse.microprofile.config.spi.Converter` with the fully qualified class name of the custom implementation.
 
 A custom `Converter` can define a priority with the `@javax.annotation.Priority` annotation.

--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -48,7 +48,7 @@ All built-in ``Converter``s have the `@Priority` of `1`.
 === Adding custom Converters
 
 A custom `Converter` must implement the generic interface `org.eclipse.microprofile.config.spi.Converter`.
-The Type parameter of the interface is the target type the String is converted to. If your converter targets a wrapper of a primitive type (e.g. `java.lang.Integer`), the converter applys to both the wrapper type and the primitive type (e.g `int`)
+The Type parameter of the interface is the target type the String is converted to. If your converter targets a wrapper of a primitive type (e.g. `java.lang.Integer`), the converter applies to both the wrapper type and the primitive type (e.g `int`)
 You have to register your implementation in a file `/META-INF/services/org.eclipse.microprofile.config.spi.Converter` with the fully qualified class name of the custom implementation.
 
 A custom `Converter` can define a priority with the `@javax.annotation.Priority` annotation.


### PR DESCRIPTION
I'm adding a clarification that Converters targeting wrapper primitive types should also be applied to the corresponding primitive types.

Not sure how each implementation is handling this, but I think it makes sense.

Also, it seems there is no TCK for this, so if we agree with this I'll add some.