### PR TITLE
Introduce issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-use-case.md
+++ b/.github/ISSUE_TEMPLATE/00-use-case.md
@@ -1,0 +1,25 @@
+---
+name: Use case
+about: Describe a new use case for the specification.
+title: ''
+labels: 'use case :bulb:'
+assignees: ''
+
+---
+
+**Description**
+
+As a:
+
+- [ ] Application user/user of the configuration itself
+- [ ] API user (application developer)
+- [ ] SPI user (container or runtime developer)
+- [ ] Specification implementer
+
+...I need to be able to:
+
+<!-- please provide your use case details here -->
+
+...which enables me to:
+
+<!-- please provide the expected benefit of solving use case here -->

--- a/.github/ISSUE_TEMPLATE/10-clarification.md
+++ b/.github/ISSUE_TEMPLATE/10-clarification.md
@@ -1,0 +1,14 @@
+---
+name: Clarification request
+about: Request that some aspect of the specification be clarified.
+title: ''
+labels: 'clarification :mag_right:'
+assignees: ''
+
+---
+
+**Description**
+
+<!-- please describe the requested clarification here -->
+
+

--- a/.github/ISSUE_TEMPLATE/20-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/20-bug-report.md
@@ -1,0 +1,14 @@
+---
+name: Bug report
+about: Report a mistake or inconsistency in the specification code or documentation text.
+title: ''
+labels: 'bug :beetle:'
+assignees: ''
+
+---
+
+<!-- Please do not use this issue type to report a use case or an implementation idea; we have separate issue types for that! -->
+
+**Describe the bug**
+
+(Describe the problem as concisely as possible.)

--- a/.github/ISSUE_TEMPLATE/30-impl-proposal.md
+++ b/.github/ISSUE_TEMPLATE/30-impl-proposal.md
@@ -1,0 +1,19 @@
+---
+name: Implementation proposal
+about: Request or propose an implementation that solves one or more use cases.
+title: ''
+labels: 'impl. proposal :gear:'
+assignees: ''
+
+---
+
+**Description**
+
+<!-- Describe the implementation proposal's functionality here -->
+
+
+**Use cases**
+
+<!-- Link at least one use case issue ID which would be solved by this implementation proposal -->
+
+* Fixes #xxxx

--- a/.github/ISSUE_TEMPLATE/40-process-change.md
+++ b/.github/ISSUE_TEMPLATE/40-process-change.md
@@ -1,0 +1,16 @@
+---
+name: Process change proposal
+about: Describe a change in the process of managing the specification project.
+title: ''
+labels: 'process change :busts_in_silhouette:'
+assignees: ''
+
+---
+
+**Description**
+
+<!-- please describe the proposed process change here -->
+
+***Footnote***
+
+Please indicate your support for this issue by choosing the :+1: reaction, rather than adding a "+1" or similar comment.

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <links>https://osgi.org/javadoc/r6/annotation/</links>
-        
+
         <checkstyle.version>2.17</checkstyle.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
     </properties>
@@ -43,7 +43,7 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
-    
+
     <organization>
         <name>Eclipse Foundation</name>
         <url>http://www.eclipse.org/</url>
@@ -60,17 +60,17 @@
             <url>https://github.com/Emily-Jiang</url>
             <organization>IBM</organization>
             <organizationUrl>https://www.ibm.com</organizationUrl>
-        </developer>    
+        </developer>
         <developer>
             <name>Mark Struberg</name>
             <url>https://github.com/struberg</url>
-        </developer>    
+        </developer>
         <developer>
             <name>Ondro Mihalyi</name>
             <url>https://github.com/OndrejM</url>
             <organization>Payara Services</organization>
             <organizationUrl>https://www.payara.fish</organizationUrl>
-        </developer>    
+        </developer>
     </developers>
 
     <scm>
@@ -223,7 +223,7 @@
                             </module>
                             <module name="FileTabCharacter" />
                             <module name="TreeWalker">
-                                
+
                                 <module name="ConstantName">
                                     <property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$" />
                                 </module>
@@ -308,13 +308,14 @@
                         <exclude>.checkstyle</exclude>
                         <exclude>.factorypath</exclude>
                         <exclude>.editorconfig</exclude>
+                        <exclude>.github/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>
 
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
**Description**

This change introduces the usage of GitHub issue templates.  This helps to ensure that each opened issue has exactly one type, and that implementation changes relate back to use cases as discussed previously.

***Footnote***

Please indicate your support for this issue by choosing the :+1: reaction, rather than adding a "+1" or similar comment.
