### PR TITLE
#418 config profile support

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
@@ -116,6 +116,17 @@ public interface ConfigBuilder {
     <T> ConfigBuilder withConverter(Class<T> type, int priority, Converter<T> converter);
 
     /**
+     * Set the configuration profile.
+     * Once the configuration profile is set, the configuration property {@code %profile.config.name} overrides the property {@code config.name} 
+     * in the same configuration source. 
+     * The configuration value for the property {@code config.name} is retrieved from a configuration source with the highest ordinal. 
+     * The value is set by the property {@code %profile.config.name} if exists. Otherwise, the value is taken from the property {@code config.name}.
+     * @param profile the configuration profile name (must not be {@code null})
+     * @return this builder
+     */
+    ConfigBuilder withProfile(String profile);
+    
+    /**
      * Build a new {@link Config} instance based on this builder instance.
      *
      * @return the new configuration object

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
@@ -114,17 +114,6 @@ public interface ConfigBuilder {
      * @return this configuration builder instance
      */
     <T> ConfigBuilder withConverter(Class<T> type, int priority, Converter<T> converter);
-
-    /**
-     * Set the configuration profile.
-     * Once the configuration profile is set, the configuration property {@code %profile.config.name} overrides the property {@code config.name} 
-     * in the same configuration source. 
-     * The configuration value for the property {@code config.name} is retrieved from a configuration source with the highest ordinal. 
-     * The value is set by the property {@code %profile.config.name} if exists. Otherwise, the value is taken from the property {@code config.name}.
-     * @param profile the configuration profile name (must not be {@code null})
-     * @return this builder
-     */
-    ConfigBuilder withProfile(String profile);
     
     /**
      * Build a new {@link Config} instance based on this builder instance.

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -69,10 +69,9 @@ The properties `%live.vehicle.name` and `%testing.vehicle.name` are inactive con
 
 If `mp.config.profile` is set to `live`, the property `%live.vehicle.name` is the active property. The `vehicleName` will be `train`. Similarly, `bike` will be the value of `vehicleName`, if the profile is `testing`.
 
-When retrieving the config values, this Config spec implementations must first search for the value of `mp.config.profile` (e.g. <profile name>) and then retrieve the value of the config property `%<profile name>.vehicle.name`,
-with the consideration of config source hierarchy specified via ordinal. It means if more than one config sources contain the same property `%<profile name>.vehicle.name`, 
-the value from the config source with the highest ordinal will be used. In the same config source, the property `%<profile name>.vehicle.name` overrides the config property `vehicle.name`. 
-If the property `%<profile name>.vehicle.name` does not exist, the value of the property `vehicle.name` will be retrieved.
+Conforming implementations are required to search for a configuration source with the highest ordinal (priority) that provides either the property name or the "profile-specific" property name. 
+If the configuration source provides the "profile-specific" name, the value of the "profile-specific" property will be returned. If it doesn't contain the "profile-specific" name, the value of the plain property will be returned. 
+A "profile-specific" property name is defined as a property whose name consists of the following sequence: `% <profile name>.<original property name>`.
 
 The above algorithm applies to the following programmatic lookup as well.
 

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -34,7 +34,7 @@ This is because the name of the profile is directly stored in the name of the co
 java -jar myapp.jar -Dmp.config.profile=testing
 ----
 
-The value of the property `mp.config.profile` shouldn't be updated after the application is started. It's only read once and will not be update once the `Config` object is constructed. If the property value of `mp.config.profile` is modified afterwards, the behavior is undefined and any changes to its value made later can be ignored by the implementation. 
+The value of the property `mp.config.profile` shouldn't be updated after the application is started. It's only read once and will not be updated once the `Config` object is constructed. If the property value of `mp.config.profile` is modified afterwards, the behavior is undefined and any changes to its value made later can be ignored by the implementation. 
 
 The value of the property `mp.config.profile` specifies a single active profile. Only one profile can be active at a time. Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is active instead of two active profiles. 
 If the property `mp.config.profile` is specified in multiple config sources, the value of the property is determined following the same rules as other configuration properties, which means the value in the config source with the highest ordinal wins.
@@ -47,7 +47,7 @@ Conforming implementations are required to search for a configuration source wit
 If the configuration source provides the "profile-specific" name, the value of the "profile-specific" property will be returned. If it doesn't contain the "profile-specific" name, the value of the plain property will be returned. 
 
 
-For an instance, a config source can be specified as follows.
+For instance, a config source can be specified as follows.
 
 [source, text]
 ----

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -27,20 +27,25 @@ Config Profile indicates the project phase, such as dev, testing, live, etc.
 === Specify Config Profile
 
 The config profile can be specified via the property `mp.config.profile`, which can be set in any of the configuration sources. The value of the property can contain only characters that are valid for config property names. 
-This is because the name of the profile is directly stored in the name of the config property. It can be set when starting your microservice. e.g.
+This is because the name of the profile is directly stored in the name of the config property. It can be set when starting your application. e.g.
 
 [source, text]
 ----
 java -jar myapp.jar -Dmp.config.profile=testing
 ----
 
-The property `mp.config.profile` is only read once on microservice starting. Any changes after that is ignored. Furthermore, the value specifies a single profile. Only one profile can be active at a time.
-Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is enabled instead of enabling two profiles. If the property `mp.config.profile` is specified in multiple config sources, 
-the value of the property is determined following the same rules as other configuration properties, which means the value in the config source with the highest ordinal wins.
+The value of the property `mp.config.profile` shouldn't be updated after the JVM is started. It's only read once during the JVM start up. If the property value is modified afterwards, the behavior is undefined and any changes to its value made later can be ignored by the implementation. 
+
+The value of the property `mp.config.profile` specifies a single active profile. Only one profile can be active at a time. Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is active instead of two active profiles. 
+If the property `mp.config.profile` is specified in multiple config sources, the value of the property is determined following the same rules as other configuration properties, which means the value in the config source with the highest ordinal wins.
 
 === How Config Profile works
 
-In supporting the Config Profile, the configuration property that utlises the Config Profile needs to have its name starting with the naming convention of `%configProfile.`, (e.g. `%live.vehicle.name`).
+The configuration property that utilizes the Config Profile is called a "profile-specific" property. A "profile-specific" property name consists of the following sequence: `% <profile name>.<original property name>`.
+
+Conforming implementations are required to search for a configuration source with the highest ordinal (priority) that provides either the property name or the "profile-specific" property name. 
+If the configuration source provides the "profile-specific" name, the value of the "profile-specific" property will be returned. If it doesn't contain the "profile-specific" name, the value of the plain property will be returned. 
+
 
 For an instance, a config source can be specified as follows.
 
@@ -69,11 +74,4 @@ In more details, if `mp.config.profile` is set to `dev`, the property `%dev.vehi
 The properties `%live.vehicle.name` and `%testing.vehicle.name` are inactive config properties and don't override the property `vehicle.name`.
 
 If `mp.config.profile` is set to `live`, the property `%live.vehicle.name` is the active property. The `vehicleName` will be `train`. Similarly, `bike` will be the value of `vehicleName`, if the profile is `testing`.
-
-Conforming implementations are required to search for a configuration source with the highest ordinal (priority) that provides either the property name or the "profile-specific" property name. 
-If the configuration source provides the "profile-specific" name, the value of the "profile-specific" property will be returned. If it doesn't contain the "profile-specific" name, the value of the plain property will be returned. 
-A "profile-specific" property name is defined as a property whose name consists of the following sequence: `% <profile name>.<original property name>`.
-
-The above algorithm applies to the following programmatic lookup as well.
-
 

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Contributors:
+// Emily Jiang
+
+
+[[configprofile]]
+== Config Profile
+
+Config Profile indicates the project phase, such as dev, testing, live, etc. 
+
+=== Specify Config Profile
+
+The config profile can be specified via a system property or an environment viable `mp.config.profile`. It can be set when starting your microservice. The value of the property can contain only characters that are valid for config property names. 
+This is because the name of the profile is directly stored in the name of the config property. e.g.
+
+[source, text]
+----
+java -jar myapp.jar -Dmp.config.profile=testing
+----
+
+The property `mp.config.profile` is only read once on microservice starting. Any changes after that is ignored. Furthermore, the value specifies a single profile. Only one profile can be active at a time.
+Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is enabled instead of enabling two profiles. 
+
+=== How Config Profile works
+
+In supporting the Config Profile, the config property names will need to start with the naming convention of `%configProfile.`, (e.g. `%live.vehicle.name`).
+
+For an instance, a config source can be specified as follows.
+
+[source, text]
+----
+%dev.vehicle.name=car
+%live.vehicle.name=train
+%testing.vehicle.name=bike
+vehicle.name=lorry
+----
+
+A config property associated with the Config Profile can be looked up as shown below.
+
+[source, text]
+----
+@Inject @ConfigProperty(name="vehicle.name") String vehicleName;
+----
+
+[source, text]
+----
+String vehicleName = ConfigProvider.getConfig().getValue("vehicle.name", String.class);
+----
+
+If the system property or environment variable `mp.config.profile` is set to `dev`, the property `%dev.vehicle.name` is the Active Property. An active property overrides the properties in the same config source. 
+In more details, if `mp.config.profile` is set to `dev`, the property `%dev.vehicle.name` overrides the property `vehicle.name`. The `vehicleName` will be set to `car`.
+The properties `%live.vehicle.name` and `%testing.vehicle.name` are inactive config properties and don't override the property `vehicle.name`.
+
+If `mp.config.profile` is set to `live`, the property `%live.vehicle.name` is the active property. The `vehicleName` will be `train`. Similarly, `bike` will be the value of `vehicleName`, if the profile is `testing`.
+
+When retrieving the config values, this Config spec implementations must first search for the value of `mp.config.profile` (e.g. <profile name>) and then retrieve the value of the config property `%<profile name>.vehicle.name`,
+with the consideration of config source hierarchy specified via ordinal. It means if more than one config sources contain the same property `%<profile name>.vehicle.name`, 
+the value from the config source with the highest ordinal will be used. In the same config source, the property `%<profile name>.vehicle.name` overrides the config property `vehicle.name`. 
+If the property `%<profile name>.vehicle.name` does not exist, the value of the property `vehicle.name` will be retrieved.
+
+The above algorithm applies to the following programmatic lookup as well.
+
+

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -26,8 +26,8 @@ Config Profile indicates the project phase, such as dev, testing, live, etc.
 
 === Specify Config Profile
 
-The config profile can be specified via a system property or an environment viable `mp.config.profile`. It can be set when starting your microservice. The value of the property can contain only characters that are valid for config property names. 
-This is because the name of the profile is directly stored in the name of the config property. e.g.
+The config profile can be specified via the property `mp.config.profile`, which can be set in any of the configuration sources. The value of the property can contain only characters that are valid for config property names. 
+This is because the name of the profile is directly stored in the name of the config property. It can be set when starting your microservice. e.g.
 
 [source, text]
 ----
@@ -35,11 +35,12 @@ java -jar myapp.jar -Dmp.config.profile=testing
 ----
 
 The property `mp.config.profile` is only read once on microservice starting. Any changes after that is ignored. Furthermore, the value specifies a single profile. Only one profile can be active at a time.
-Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is enabled instead of enabling two profiles. 
+Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is enabled instead of enabling two profiles. If the property `mp.config.profile` is specified in multiple config sources, 
+the value of the property is determined following the same rules as other configuration properties, which means the value in the config source with the highest ordinal wins.
 
 === How Config Profile works
 
-In supporting the Config Profile, the config property names will need to start with the naming convention of `%configProfile.`, (e.g. `%live.vehicle.name`).
+In supporting the Config Profile, the configuration property that utlises the Config Profile needs to have its name starting with the naming convention of `%configProfile.`, (e.g. `%live.vehicle.name`).
 
 For an instance, a config source can be specified as follows.
 
@@ -63,7 +64,7 @@ A config property associated with the Config Profile can be looked up as shown b
 String vehicleName = ConfigProvider.getConfig().getValue("vehicle.name", String.class);
 ----
 
-If the system property or environment variable `mp.config.profile` is set to `dev`, the property `%dev.vehicle.name` is the Active Property. An active property overrides the properties in the same config source. 
+If the property `mp.config.profile` is set to `dev`, the property `%dev.vehicle.name` is the Active Property. An active property overrides the properties in the same config source. 
 In more details, if `mp.config.profile` is set to `dev`, the property `%dev.vehicle.name` overrides the property `vehicle.name`. The `vehicleName` will be set to `car`.
 The properties `%live.vehicle.name` and `%testing.vehicle.name` are inactive config properties and don't override the property `vehicle.name`.
 

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -34,7 +34,7 @@ This is because the name of the profile is directly stored in the name of the co
 java -jar myapp.jar -Dmp.config.profile=testing
 ----
 
-The value of the property `mp.config.profile` shouldn't be updated after the application is started. It's only read once during the application start up. If the property value is modified afterwards, the behavior is undefined and any changes to its value made later can be ignored by the implementation. 
+The value of the property `mp.config.profile` shouldn't be updated after the application is started. It's only read once and will not be update once the `Config` object is constructed. If the property value of `mp.config.profile` is modified afterwards, the behavior is undefined and any changes to its value made later can be ignored by the implementation. 
 
 The value of the property `mp.config.profile` specifies a single active profile. Only one profile can be active at a time. Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is active instead of two active profiles. 
 If the property `mp.config.profile` is specified in multiple config sources, the value of the property is determined following the same rules as other configuration properties, which means the value in the config source with the highest ordinal wins.

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -34,7 +34,7 @@ This is because the name of the profile is directly stored in the name of the co
 java -jar myapp.jar -Dmp.config.profile=testing
 ----
 
-The value of the property `mp.config.profile` shouldn't be updated after the JVM is started. It's only read once during the JVM start up. If the property value is modified afterwards, the behavior is undefined and any changes to its value made later can be ignored by the implementation. 
+The value of the property `mp.config.profile` shouldn't be updated after the application is started. It's only read once during the application start up. If the property value is modified afterwards, the behavior is undefined and any changes to its value made later can be ignored by the implementation. 
 
 The value of the property `mp.config.profile` specifies a single active profile. Only one profile can be active at a time. Commas in the value have no special meaning. For example, if the value of `mp.config.profile` is `testing,live`,  a single profile named `testing,live` is active instead of two active profiles. 
 If the property `mp.config.profile` is specified in multiple config sources, the value of the property is determined following the same rules as other configuration properties, which means the value in the config source with the highest ordinal wins.

--- a/spec/src/main/asciidoc/configprovider.asciidoc
+++ b/spec/src/main/asciidoc/configprovider.asciidoc
@@ -59,7 +59,7 @@ ConfigBuilder builder = resolver.getBuilder();
 ** Add config sources and build:
 +
 ```
-Config config = builder.addDefaultSources().withSources(mySource).withConverters(myConverter).withProfile(profile).build;
+Config config = builder.addDefaultSources().withSources(mySource).withConverters(myConverter).build;
 ```
 ** (optional) Manage the lifecycle of the config
 +

--- a/spec/src/main/asciidoc/configprovider.asciidoc
+++ b/spec/src/main/asciidoc/configprovider.asciidoc
@@ -59,7 +59,7 @@ ConfigBuilder builder = resolver.getBuilder();
 ** Add config sources and build:
 +
 ```
-Config config = builder.addDefaultSources().withSources(mySource).withConverters(myConverter).build;
+Config config = builder.addDefaultSources().withSources(mySource).withConverters(myConverter).withProfile(profile).build;
 ```
 ** (optional) Manage the lifecycle of the config
 +

--- a/spec/src/main/asciidoc/microprofile-config-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-config-spec.asciidoc
@@ -46,4 +46,6 @@ include::configsources.asciidoc[]
 
 include::converters.asciidoc[]
 
+include::configprofile.asciidoc[]
+
 include::release_notes.asciidoc[]

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/CustomConfigProfileConfigSource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/CustomConfigProfileConfigSource.java
@@ -44,6 +44,7 @@ public class CustomConfigProfileConfigSource implements ConfigSource {
     public int getOrdinal() {
         return 500;
     }
+
     @Override
     public String getValue(String key) {
         return configValues.get(key);
@@ -54,12 +55,8 @@ public class CustomConfigProfileConfigSource implements ConfigSource {
         return "customConfigProfileSource";
     }
 
-
     @Override
-    public Set<String> getPropertyNames() {
-        
+    public Set<String> getPropertyNames() {    
         return configValues.keySet();
     }
-
-
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/CustomConfigProfileConfigSource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/CustomConfigProfileConfigSource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.config.tck.configsources;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+/**
+ * @author Emily Jiang
+ */
+public class CustomConfigProfileConfigSource implements ConfigSource {
+
+    private Map<String, String> configValues = new HashMap<>();
+
+    public CustomConfigProfileConfigSource() {
+        configValues.put("mp.config.profile", "test");
+        configValues.put("%dev.vehicle.name", "bike");
+        configValues.put("%prod.vehicle.name", "bus");
+        configValues.put("%test.vehicle.name", "van");
+        configValues.put("vehicle.name", "car");
+    }
+
+    @Override
+    public int getOrdinal() {
+        return 500;
+    }
+    @Override
+    public String getValue(String key) {
+        return configValues.get(key);
+    }
+
+    @Override
+    public String getName() {
+        return "customConfigProfileSource";
+    }
+
+
+    @Override
+    public Set<String> getPropertyNames() {
+        
+        return configValues.keySet();
+    }
+
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.config.tck.profile;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.tck.base.AbstractTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for Config profile
+ * 
+ * @author Emily Jiang
+ */
+public class DevConfigProfileTest extends Arquillian {
+
+    
+    @Deployment
+    public static Archive deployment() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "DevConfigProfileTest.jar")
+                .addClasses(DevConfigProfileTest.class, ProfilePropertyBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
+
+        AbstractTest.addFile(testJar, "META-INF/microprofile-config.properties");
+
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "DevConfigProfileTest.war")
+                .addAsLibrary(testJar);
+        return war;
+       
+    }
+
+    @BeforeTest
+    public void setUpTest() {
+        clearAllPropertyValues();
+        ensureAllPropertyValuesAreDefined();
+    }
+
+    @Test
+    public void testConfigProfileWithDev() {
+        ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
+
+        assertThat(bean.getConfigProperty(), is(equalTo("bike")));
+        assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("bike")));
+    }
+
+    private void ensureAllPropertyValuesAreDefined() {
+        System.setProperty("mp.config.profile", "dev");
+        
+    }
+
+    private void clearAllPropertyValues() {
+        System.getProperties().remove("mp.config.profile");
+        
+    }
+
+    @Dependent
+    public static class ProfilePropertyBean {
+        @Inject
+        @ConfigProperty(name="vehicle.name")
+        private String vehicleName;
+
+        public String getConfigProperty() {
+            return vehicleName;
+        }
+    }
+    
+    
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
@@ -32,15 +32,14 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.config.tck.base.AbstractTest;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
@@ -56,10 +55,18 @@ public class DevConfigProfileTest extends Arquillian {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "DevConfigProfileTest.jar")
                 .addClasses(DevConfigProfileTest.class, ProfilePropertyBean.class)
+                .addAsManifestResource(
+                    new StringAsset(
+                        "mp.config.profile=dev\n" +
+                        "%dev.vehicle.name=bike\n" +
+                        "%prod.vehicle.name=bus\n" +
+                        "%test.vehicle.name=van\n" +
+                        "vehicle.name=car"),
+                        "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 
-        AbstractTest.addFile(testJar, "META-INF/microprofile-config.properties");
+                
 
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "DevConfigProfileTest.war")
@@ -68,11 +75,6 @@ public class DevConfigProfileTest extends Arquillian {
        
     }
 
-    @BeforeTest
-    public void setUpTest() {
-        clearAllPropertyValues();
-        ensureAllPropertyValuesAreDefined();
-    }
 
     @Test
     public void testConfigProfileWithDev() {
@@ -82,15 +84,6 @@ public class DevConfigProfileTest extends Arquillian {
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("bike")));
     }
 
-    private void ensureAllPropertyValuesAreDefined() {
-        System.setProperty("mp.config.profile", "dev");
-        
-    }
-
-    private void clearAllPropertyValues() {
-        System.getProperties().remove("mp.config.profile");
-        
-    }
 
     @Dependent
     public static class ProfilePropertyBean {

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
@@ -48,8 +48,7 @@ import org.testng.annotations.Test;
  * @author Emily Jiang
  */
 public class DevConfigProfileTest extends Arquillian {
-
-    
+   
     @Deployment
     public static Archive deployment() {
         JavaArchive testJar = ShrinkWrap
@@ -64,9 +63,7 @@ public class DevConfigProfileTest extends Arquillian {
                         "vehicle.name=car"),
                         "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
-
-                
+                .as(JavaArchive.class);   
 
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "DevConfigProfileTest.war")
@@ -75,26 +72,20 @@ public class DevConfigProfileTest extends Arquillian {
        
     }
 
-
     @Test
     public void testConfigProfileWithDev() {
         ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
-
         assertThat(bean.getConfigProperty(), is(equalTo("bike")));
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("bike")));
     }
-
 
     @Dependent
     public static class ProfilePropertyBean {
         @Inject
         @ConfigProperty(name="vehicle.name")
         private String vehicleName;
-
         public String getConfigProperty() {
             return vehicleName;
         }
-    }
-    
-    
+    }    
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.config.tck.profile;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.tck.base.AbstractTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for Config profile
+ * 
+ * @author Emily Jiang
+ */
+public class InvalidConfigProfileTest extends Arquillian {
+
+    
+    @Deployment
+    public static Archive deployment() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "InvalidConfigProfileTest.jar")
+                .addClasses(InvalidConfigProfileTest.class, ProfilePropertyBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
+
+        AbstractTest.addFile(testJar, "META-INF/microprofile-config.properties");
+
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "InvalidConfigProfileTest.war")
+                .addAsLibrary(testJar);
+        return war;
+       
+    }
+
+    @BeforeTest
+    public void setUpTest() {
+        clearAllPropertyValues();
+        ensureAllPropertyValuesAreDefined();
+    }
+
+    @Test
+    public void testConfigProfileWithDev() {
+        ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
+
+        assertThat(bean.getConfigProperty(), is(equalTo("car")));
+        assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("car")));
+    }
+
+    private void ensureAllPropertyValuesAreDefined() {
+        System.setProperty("mp.config.profile", "invalid");
+        
+    }
+
+    private void clearAllPropertyValues() {
+        System.getProperties().remove("mp.config.profile");
+        
+    }
+
+    @Dependent
+    public static class ProfilePropertyBean {
+        @Inject
+        @ConfigProperty(name="vehicle.name")
+        private String vehicleName;
+
+        public String getConfigProperty() {
+            return vehicleName;
+        }
+    }
+    
+    
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
@@ -49,7 +49,6 @@ import org.testng.annotations.Test;
  * @author Emily Jiang
  */
 public class InvalidConfigProfileTest extends Arquillian {
-
     
     @Deployment
     public static Archive deployment() {
@@ -73,30 +72,22 @@ public class InvalidConfigProfileTest extends Arquillian {
                 .create(WebArchive.class, "InvalidConfigProfileTest.war")
                 .addAsLibrary(testJar);
         return war;
-       
     }
-
 
     @Test
     public void testConfigProfileWithDev() {
         ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
-
         assertThat(bean.getConfigProperty(), is(equalTo("car")));
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("car")));
     }
-
-
 
     @Dependent
     public static class ProfilePropertyBean {
         @Inject
         @ConfigProperty(name="vehicle.name")
         private String vehicleName;
-
         public String getConfigProperty() {
             return vehicleName;
         }
-    }
-    
-    
+    }    
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
@@ -38,9 +38,9 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
@@ -56,6 +56,14 @@ public class InvalidConfigProfileTest extends Arquillian {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "InvalidConfigProfileTest.jar")
                 .addClasses(InvalidConfigProfileTest.class, ProfilePropertyBean.class)
+                .addAsManifestResource(
+                    new StringAsset(
+                        "mp.config.profile=invalid\n" +
+                        "%dev.vehicle.name=bike\n" +
+                        "%prod.vehicle.name=bus\n" +
+                        "%test.vehicle.name=van\n" +
+                        "vehicle.name=car"),
+                        "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 
@@ -68,11 +76,6 @@ public class InvalidConfigProfileTest extends Arquillian {
        
     }
 
-    @BeforeTest
-    public void setUpTest() {
-        clearAllPropertyValues();
-        ensureAllPropertyValuesAreDefined();
-    }
 
     @Test
     public void testConfigProfileWithDev() {
@@ -82,15 +85,7 @@ public class InvalidConfigProfileTest extends Arquillian {
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("car")));
     }
 
-    private void ensureAllPropertyValuesAreDefined() {
-        System.setProperty("mp.config.profile", "invalid");
-        
-    }
 
-    private void clearAllPropertyValues() {
-        System.getProperties().remove("mp.config.profile");
-        
-    }
 
     @Dependent
     public static class ProfilePropertyBean {

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ProdProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ProdProfileTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.config.tck.profile;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.tck.base.AbstractTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for Config profile
+ * 
+ * @author Emily Jiang
+ */
+public class ProdProfileTest extends Arquillian {
+
+    
+    @Deployment
+    public static Archive deployment() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "ProdProfileTest.jar")
+                .addClasses(ProdProfileTest.class, ProfilePropertyBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
+
+        AbstractTest.addFile(testJar, "META-INF/microprofile-config.properties");
+
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "ProdProfileTest.war")
+                .addAsLibrary(testJar);
+        return war;
+       
+    }
+
+    @BeforeTest
+    public void setUpTest() {
+        clearAllPropertyValues();
+        ensureAllPropertyValuesAreDefined();
+    }
+
+    @Test
+    public void testConfigProfileWithDev() {
+        ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
+
+        assertThat(bean.getConfigProperty(), is(equalTo("bus")));
+        assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("bus")));
+    }
+
+    private void ensureAllPropertyValuesAreDefined() {
+        System.setProperty("mp.config.profile", "prod");
+        
+    }
+
+    private void clearAllPropertyValues() {
+        System.getProperties().remove("mp.config.profile");
+        
+    }
+
+    @Dependent
+    public static class ProfilePropertyBean {
+        @Inject
+        @ConfigProperty(name="vehicle.name")
+        private String vehicleName;
+
+        public String getConfigProperty() {
+            return vehicleName;
+        }
+    }
+    
+    
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ProdProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ProdProfileTest.java
@@ -49,7 +49,6 @@ import org.testng.annotations.Test;
  * @author Emily Jiang
  */
 public class ProdProfileTest extends Arquillian {
-
     
     @Deployment
     public static Archive deployment() {
@@ -73,30 +72,22 @@ public class ProdProfileTest extends Arquillian {
                 .create(WebArchive.class, "ProdProfileTest.war")
                 .addAsLibrary(testJar);
         return war;
-       
     }
-
-
 
     @Test
     public void testConfigProfileWithDev() {
         ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
-
         assertThat(bean.getConfigProperty(), is(equalTo("bus")));
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("bus")));
     }
-
 
     @Dependent
     public static class ProfilePropertyBean {
         @Inject
         @ConfigProperty(name="vehicle.name")
         private String vehicleName;
-
         public String getConfigProperty() {
             return vehicleName;
         }
-    }
-    
-    
+    }      
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
@@ -38,9 +38,9 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
@@ -56,6 +56,14 @@ public class TestConfigProfileTest extends Arquillian {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "TestConfigProfileTest.jar")
                 .addClasses(TestConfigProfileTest.class, ProfilePropertyBean.class)
+                .addAsManifestResource(
+                    new StringAsset(
+                        "mp.config.profile=test\n" +
+                        "%dev.vehicle.name=bike\n" +
+                        "%prod.vehicle.name=bus\n" +
+                        "%test.vehicle.name=van\n" +
+                        "vehicle.name=car"),
+                        "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 
@@ -69,28 +77,12 @@ public class TestConfigProfileTest extends Arquillian {
     }
 
 
-    @BeforeTest
-    public void setUpTest() {
-        clearAllPropertyValues();
-        ensureAllPropertyValuesAreDefined();
-    }
-
     @Test
     public void testConfigProfileWithDev() {
         ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
 
         assertThat(bean.getConfigProperty(), is(equalTo("van")));
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("van")));
-    }
-
-    private void ensureAllPropertyValuesAreDefined() {
-        System.setProperty("mp.config.profile", "test");
-        
-    }
-
-    private void clearAllPropertyValues() {
-        System.getProperties().remove("mp.config.profile");
-        
     }
 
     @Dependent

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.config.tck.profile;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.tck.base.AbstractTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for Config profile
+ * 
+ * @author Emily Jiang
+ */
+public class TestConfigProfileTest extends Arquillian {
+
+    
+    @Deployment
+    public static Archive deployment() {
+        JavaArchive testJar = ShrinkWrap
+                .create(JavaArchive.class, "TestConfigProfileTest.jar")
+                .addClasses(TestConfigProfileTest.class, ProfilePropertyBean.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
+
+        AbstractTest.addFile(testJar, "META-INF/microprofile-config.properties");
+
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "TestConfigProfileTest.war")
+                .addAsLibrary(testJar);
+        return war;
+       
+    }
+
+
+    @BeforeTest
+    public void setUpTest() {
+        clearAllPropertyValues();
+        ensureAllPropertyValuesAreDefined();
+    }
+
+    @Test
+    public void testConfigProfileWithDev() {
+        ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
+
+        assertThat(bean.getConfigProperty(), is(equalTo("van")));
+        assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("van")));
+    }
+
+    private void ensureAllPropertyValuesAreDefined() {
+        System.setProperty("mp.config.profile", "test");
+        
+    }
+
+    private void clearAllPropertyValues() {
+        System.getProperties().remove("mp.config.profile");
+        
+    }
+
+    @Dependent
+    public static class ProfilePropertyBean {
+        @Inject
+        @ConfigProperty(name="vehicle.name")
+        private String vehicleName;
+
+        public String getConfigProperty() {
+            return vehicleName;
+        }
+    }
+    
+    
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
@@ -49,7 +49,6 @@ import org.testng.annotations.Test;
  * @author Emily Jiang
  */
 public class TestConfigProfileTest extends Arquillian {
-
     
     @Deployment
     public static Archive deployment() {
@@ -76,11 +75,9 @@ public class TestConfigProfileTest extends Arquillian {
        
     }
 
-
     @Test
     public void testConfigProfileWithDev() {
         ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
-
         assertThat(bean.getConfigProperty(), is(equalTo("van")));
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("van")));
     }
@@ -90,11 +87,8 @@ public class TestConfigProfileTest extends Arquillian {
         @Inject
         @ConfigProperty(name="vehicle.name")
         private String vehicleName;
-
         public String getConfigProperty() {
             return vehicleName;
         }
-    }
-    
-    
+    }     
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestCustomConfigProfile.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestCustomConfigProfile.java
@@ -32,7 +32,9 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.tck.base.AbstractTest;
+import org.eclipse.microprofile.config.tck.configsources.CustomConfigProfileConfigSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -48,20 +50,22 @@ import org.testng.annotations.Test;
  * 
  * @author Emily Jiang
  */
-public class ProdProfileTest extends Arquillian {
+public class TestCustomConfigProfile extends Arquillian {
 
     
     @Deployment
     public static Archive deployment() {
         JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "ProdProfileTest.jar")
-                .addClasses(ProdProfileTest.class, ProfilePropertyBean.class)
+                .create(JavaArchive.class, "TestConfigProfileTest.jar")
+                .addClasses(TestCustomConfigProfile.class, ProfilePropertyBean.class, CustomConfigProfileConfigSource.class)
+                .addAsServiceProvider(ConfigSource.class, CustomConfigProfileConfigSource.class)
+           
                 .addAsManifestResource(
                     new StringAsset(
                         "mp.config.profile=prod\n" +
-                        "%dev.vehicle.name=bike\n" +
-                        "%prod.vehicle.name=bus\n" +
-                        "%test.vehicle.name=van\n" +
+                        "%dev.vehicle.name=bus\n" +
+                        "%prod.vehicle.name=bike\n" +
+                        "%test.vehicle.name=coach\n" +
                         "vehicle.name=car"),
                         "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
@@ -70,22 +74,20 @@ public class ProdProfileTest extends Arquillian {
         AbstractTest.addFile(testJar, "META-INF/microprofile-config.properties");
 
         WebArchive war = ShrinkWrap
-                .create(WebArchive.class, "ProdProfileTest.war")
+                .create(WebArchive.class, "TestConfigProfileTest.war")
                 .addAsLibrary(testJar);
         return war;
        
     }
 
 
-
     @Test
     public void testConfigProfileWithDev() {
         ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
 
-        assertThat(bean.getConfigProperty(), is(equalTo("bus")));
-        assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("bus")));
+        assertThat(bean.getConfigProperty(), is(equalTo("van")));
+        assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("van")));
     }
-
 
     @Dependent
     public static class ProfilePropertyBean {

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestCustomConfigProfile.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestCustomConfigProfile.java
@@ -52,14 +52,12 @@ import org.testng.annotations.Test;
  */
 public class TestCustomConfigProfile extends Arquillian {
 
-    
     @Deployment
     public static Archive deployment() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "TestConfigProfileTest.jar")
                 .addClasses(TestCustomConfigProfile.class, ProfilePropertyBean.class, CustomConfigProfileConfigSource.class)
                 .addAsServiceProvider(ConfigSource.class, CustomConfigProfileConfigSource.class)
-           
                 .addAsManifestResource(
                     new StringAsset(
                         "mp.config.profile=prod\n" +
@@ -80,11 +78,9 @@ public class TestCustomConfigProfile extends Arquillian {
        
     }
 
-
     @Test
     public void testConfigProfileWithDev() {
         ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
-
         assertThat(bean.getConfigProperty(), is(equalTo("van")));
         assertThat(ConfigProvider.getConfig().getValue("vehicle.name", String.class), is(equalTo("van")));
     }
@@ -94,11 +90,8 @@ public class TestCustomConfigProfile extends Arquillian {
         @Inject
         @ConfigProperty(name="vehicle.name")
         private String vehicleName;
-
         public String getConfigProperty() {
             return vehicleName;
         }
-    }
-    
-    
+    }    
 }

--- a/tck/src/main/resources/internal/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/internal/META-INF/microprofile-config.properties
@@ -166,3 +166,9 @@ tck.config.test.javaconfig.converter.urlvalues=http://microprofile.io,http://ope
 
 tck.config.test.javaconfig.converter.class=org.eclipse.microprofile.config.tck.ClassConverterTest
 tck.config.test.javaconfig.converter.class.array=org.eclipse.microprofile.config.tck.ClassConverterTest,java.lang.String
+
+#config profile tests
+%dev.vehicle.name=bike
+%prod.vehicle.name=bus
+%test.vehicle.name=van
+vehicle.name=car

--- a/tck/src/main/resources/internal/META-INF/microprofile-config.properties
+++ b/tck/src/main/resources/internal/META-INF/microprofile-config.properties
@@ -167,8 +167,3 @@ tck.config.test.javaconfig.converter.urlvalues=http://microprofile.io,http://ope
 tck.config.test.javaconfig.converter.class=org.eclipse.microprofile.config.tck.ClassConverterTest
 tck.config.test.javaconfig.converter.class.array=org.eclipse.microprofile.config.tck.ClassConverterTest,java.lang.String
 
-#config profile tests
-%dev.vehicle.name=bike
-%prod.vehicle.name=bus
-%test.vehicle.name=van
-vehicle.name=car


### PR DESCRIPTION
A proposal to support standard way to provide profile-specific properties that would be used only if a profile is specified. This for example enables an application to include configuration for different environments and development stages while only one of them is active (e.g. dev, test, prod).