### PR TITLE
Adds ConfigValueResolver fluent API

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -34,9 +34,6 @@
 
 package org.eclipse.microprofile.config;
 
-import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -92,6 +89,15 @@ import org.eclipse.microprofile.config.spi.Converter;
 public interface Config {
 
     /**
+     * Return a {@link ConfigValueResolver} for more sophisticated use cases than basic resolution using
+     * {@link #getValue(String, Class)}.
+     *
+     * @param propertyName The configuration property name to resolve later on using the {@link ConfigValueResolver}
+     * @return a new instance of a {@link ConfigValueResolver} for the provided property
+     */
+    ConfigValueResolver getValue(String propertyName);
+
+    /**
      * Return the resolved property value with the specified type for the
      * specified property name from the underlying {@linkplain ConfigSource configuration sources}.
      * <p>
@@ -110,30 +116,6 @@ public interface Config {
      * @throws java.util.NoSuchElementException if the property isn't present in the configuration
      */
     <T> T getValue(String propertyName, Class<T> propertyType);
-
-    /**
-     * Return the resolved property values with the specified type for the
-     * specified property name from the underlying {@linkplain ConfigSource configuration sources}.
-     * <p>
-     * The configuration values are not guaranteed to be cached by the implementation, and may be expensive
-     * to compute; therefore, if the returned values are intended to be frequently used, callers should consider storing
-     * rather than recomputing them.
-     *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration property name
-     * @param propertyType
-     *             The type into which the resolved property values should get converted
-     * @return the resolved property values as a list of instances of the requested type
-     * @throws java.lang.IllegalArgumentException if the property values cannot be converted to the specified type
-     * @throws java.util.NoSuchElementException if the property isn't present in the configuration
-     */
-    default <T> List<T> getValues(String propertyName, Class<T> propertyType) {
-        @SuppressWarnings("unchecked")
-        Class<T[]> arrayType = (Class<T[]>) Array.newInstance(propertyType, 0).getClass();
-        return Arrays.asList(getValue(propertyName, arrayType));
-    }
 
     /**
      * Return the resolved property value with the specified type for the
@@ -156,30 +138,6 @@ public interface Config {
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
      */
     <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType);
-
-    /**
-     * Return the resolved property values with the specified type for the
-     * specified property name from the underlying {@linkplain ConfigSource configuration sources}.
-     * <p>
-     * The configuration values are not guaranteed to be cached by the implementation, and may be expensive
-     * to compute; therefore, if the returned values are intended to be frequently used, callers should consider storing
-     * rather than recomputing them.
-     *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration property name
-     * @param propertyType
-     *             The type into which the resolved property values should be converted
-     * @return The resolved property values as an {@code Optional} wrapping a list of the requested type
-     *
-     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
-     */
-    default <T> Optional<List<T>> getOptionalValues(String propertyName, Class<T> propertyType) {
-        @SuppressWarnings("unchecked")
-        Class<T[]> arrayType = (Class<T[]>) Array.newInstance(propertyType, 0).getClass();
-        return getOptionalValue(propertyName, arrayType).map(Arrays::asList);
-    }
 
     /**
      * Returns a sequence of configuration property names. The order of the returned property names is unspecified.

--- a/api/src/main/java/org/eclipse/microprofile/config/ConfigValueResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/ConfigValueResolver.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.eclipse.microprofile.config.spi.Converter;
+
 /**
  * <p>
  * This is an abstraction to resolve {@link Config} values using a fluent API that is used
@@ -57,7 +59,7 @@ import java.util.function.Function;
  *
  * <p>
  * Usually conversion relies on registered {@link org.eclipse.microprofile.config.spi.Converter}s.
- * Ad-hoc conversion can be done using {@link #asConvertedBy(Function, Object)}.
+ * Ad-hoc conversion can be done using {@link #asConvertedBy(Converter, Object)}.
  * Values resolved as {@link String} are not converted.
  * Values resolved as {@code String[]} are only split but elements are not converted.
  *
@@ -77,15 +79,6 @@ import java.util.function.Function;
  * @author <a href="mailto:jan.bernitt@payara.fish">Jan Bernitt</a>
  */
 public interface ConfigValueResolver {
-
-    /**
-     * Adds a profile to property resolution which is applied when requesting a value.
-     * Multiple calls to this method on the same instance override prior profile values.
-     *
-     * @param value name of the profile to use, {@code null} is ignored
-     * @return This resolver for fluent API usage
-     */
-    ConfigValueResolver withProfile(String value);
 
     /**
      * Provides a raw property value default value.
@@ -180,7 +173,7 @@ public interface ConfigValueResolver {
      * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
      *         exceptions has been requested using {@link #throwOnMissingProperty()}
      **/
-    <T> T asConvertedBy(Function<String, T> converter, T defaultValue);
+    <T> T asConvertedBy(Converter<T> converter, T defaultValue);
 
     /**
      * Resolves the property as {@link List}.

--- a/api/src/main/java/org/eclipse/microprofile/config/ConfigValueResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/ConfigValueResolver.java
@@ -1,0 +1,294 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *   2020-04-30 - Jan Bernitt / Payara
+ *      Initial revision
+ *
+ *******************************************************************************/
+package org.eclipse.microprofile.config;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * <p>
+ * This is an abstraction to resolve {@link Config} values using a fluent API that is used
+ * when the basic {@link Config#getValue(String, Class)} does not suffice
+ * or the user wants to make sure a value is returned without an exception and excluding empty {@link String} values.
+ * The method names are chosen for good readability when used as a fluent API.
+ *
+ * <p>
+ * This API is designed so reliably result in a return value. This means by default it will not throw exceptions for
+ * missing properties or failed conversion but instead return a default value that callers have to provide.
+ * Alternatively to providing a default value a value can be resolved as {@link Optional}.
+ *
+ * <p>
+ * Arrays of values can be resolved as {@link List} or {@link Set}.
+ * By default these return empty lists or sets in case of missing property or failed conversion.
+ *
+ * <p>
+ * Simple value properties defined as empty string by default are considered missing. This can be changed
+ * using {@link #acceptEmpty()}.
+ *
+ * <p>
+ * Should exceptions be thrown for either missing properties or failed conversion the default of not throwing exception
+ * and using default values can be overridden using {@link #throwOnMissingProperty()} and
+ * {@link #throwOnFailedConversion()}.
+ *
+ * <p>
+ * Usually conversion relies on registered {@link org.eclipse.microprofile.config.spi.Converter}s.
+ * Ad-hoc conversion can be done using {@link #asConvertedBy(Function, Object)}.
+ * Values resolved as {@link String} are not converted.
+ * Values resolved as {@code String[]} are only split but elements are not converted.
+ *
+ * <p>
+ * Typed defaults are provided with one of the {@code as}-methods.
+ * Raw property string defaults can be provided using {@link #withDefault(String)}.
+ * As the API can not capture if such a raw default has been provided it still requires to provide a typed default
+ * or use {@link Optional} to ensure resolution will return a value.
+ * If a raw {@link String} is provided it takes precedence over a typed default.
+ * Should conversion of a raw default fail the typed default is used
+ * or in case of {@link Optional} the property is considered not present.
+ *
+ * <p>
+ * The only way {@code as}-methods might return a {@code null} reference is by using {@code null} as typed default.
+ * In such case it is considered the intention of the caller and therefore not problematic.
+ *
+ * @author <a href="mailto:jan.bernitt@payara.fish">Jan Bernitt</a>
+ */
+public interface ConfigValueResolver {
+
+    /**
+     * Adds a profile to property resolution which is applied when requesting a value.
+     * Multiple calls to this method on the same instance override prior profile values.
+     *
+     * @param value name of the profile to use, {@code null} is ignored
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver withProfile(String value);
+
+    /**
+     * Provides a raw property value default value.
+     * <p>
+     * The raw default is considered to be on the source level and therefore takes precedence over typed defaults
+     * provided to any of the {@code as}-methods. Should raw default be empty of fail to convert to the target type the
+     * typed default is used.
+     *
+     * @param value raw default value, not {@code null}
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver withDefault(String value);
+
+    /**
+     * Disables the default behaviour of considering properties defined as empty string as being not present (missing).
+     * Effectively this means {@code as}-methods might then return empty things in case the property is defined as empty
+     * in the source.
+     *
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver acceptEmpty();
+
+    /**
+     * Disables the default behaviour of not throwing exceptions and instead returning default values for case of
+     * missing or empty raw value. If used in combination with {@link #acceptEmpty()} empty raw values will not throw an
+     * exception, otherwise they do.
+     *
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver throwOnMissingProperty();
+
+    /**
+     * Disables the default behaviour of not throwing exceptions and instead returning default values for case of failed
+     * conversion or missing converter for the target type.
+     *
+     * @return This resolver for fluent API usage
+     */
+    ConfigValueResolver throwOnFailedConversion();
+
+    /**
+     * Resolves the property as a simple or array type.
+     * <p>
+     * If the property is missing, defined empty, the required converter is missing or conversion fails the provided
+     * default value is returned.
+     *
+     * @param type         target type of the conversion, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or the default value
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <T> T as(Class<T> type, T defaultValue);
+
+    /**
+     * Resolves the property as a simple or array type wrapped in an {@link Optional}.
+     * <p>
+     * If the property is missing, defined empty, the required converter is missing or conversion fails
+     * {@link Optional#empty()} is returned.
+     *
+     * @param type         target type of the conversion, not {@code null}
+     * @return the resolved and converted property value as present or empty {@link Optional}
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <T> Optional<T> as(Class<T> type);
+
+    /**
+     * Resolves the property as converted by the provided converter {@link Function}.
+     * <p>
+     * If the property is missing, defined empty or the conversion fails the provided default value is returned.
+     * <p>
+     * This is meant for ad-hoc conversions using lambda expressions as converter to circumvent the need to register a
+     * special {@link org.eclipse.microprofile.config.spi.Converter} for single case use or to allow using different
+     * converter functions for same target type at multiple usages.
+     * <p>
+     * If this method is used in connection with {@link #acceptEmpty()} the empty {@link String} might be passed to the
+     * provided converter function, otherwise the empty string will be considered missing.
+     *
+     * @param type         target type of the conversion, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or the default value
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <T> T asConvertedBy(Function<String, T> converter, T defaultValue);
+
+    /**
+     * Resolves the property as {@link List}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails an
+     * empty list is returned. The returned list must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #asList(Class, List)} with an empty list as default value.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link List} while also honouring defaults.
+     *
+     * @param elementType type of the list elements, not {@code null}
+     * @return the resolved and converted property value or an empty list
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> List<E> asList(Class<E> elementType);
+
+    /**
+     * Resolves the property as {@link List}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails the
+     * provided default value is returned. The returned list must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link List} while also honouring defaults.
+     *
+     * @param elementType  type of the list elements, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or an empty list
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> List<E> asList(Class<E> elementType, List<E> defaultValue);
+
+    /**
+     * Resolves the property as {@link Set}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails an
+     * empty set is returned. The returned set must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #asSet(Class, Set)} with an empty set as default value.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link Set} while also honouring defaults.
+     *
+     * @param elementType type of the set elements, not {@code null}
+     * @return the resolved and converted property value or an empty set
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> Set<E> asSet(Class<E> elementType);
+
+    /**
+     * Resolves the property as {@link Set}.
+     * Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing or conversion fails an
+     * empty set is returned. The returned set must not be considered modifiable.
+     * <p>
+     * This is equivalent to {@link #asSet(Class, Set)} with an empty set as default value.
+     * <p>
+     * This is equivalent to {@link #as(Class, Object)} with 1-dimensional array type of the provided element type as
+     * type where the returned array is later wrapped in a {@link Set} while also honouring defaults.
+     *
+     * @param elementType  type of the set elements, not {@code null}
+     * @param defaultValue any value including null. It is returned in case of missing property or failed conversion
+     *                     unless throwing exceptions has been explicitly requested using
+     *                     {@link #throwOnMissingProperty()} or {@link #throwOnFailedConversion()}.
+     * @return the resolved and converted property value or an empty set
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> Set<E> asSet(Class<E> elementType, Set<E> defaultValue);
+
+    /**
+     * Consume successfully converted element values for multi-value properties.
+     *
+     * Resolves the property as if resolving an array of the given element type and passing each of them to the provided
+     * {@link Consumer} action. Raw value is split into elements as defined by {@link Config} for array types.
+     * <p>
+     * If the property is missing, defined empty, the required element type converter is missing the action is not called at all.
+     * If conversion fails for an element that element is skipped and not passed to the action.
+     * Other elements are still converted.
+     * <p>
+     * This method might also help avoid creation of intermediate collections to some degree.
+     * Implementations should attempt to avoid such intermediate collections where possible within reason.
+     *
+     * @param elementType type to be consumed by the provided action, not {@code null}
+     * @param action      The action to be performed for each element, not {@code null}
+     * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type and throwing
+     *         exceptions has been requested using {@link #throwOnFailedConversion()}
+     * @throws java.util.NoSuchElementException if the property isn't present in the configuration and throwing
+     *         exceptions has been requested using {@link #throwOnMissingProperty()}
+     **/
+    <E> void forEach(Class<E> elementType, Consumer<? super E> action);
+}


### PR DESCRIPTION
### Summary
This PR introduces a fluent API which has multiple intents:

* cover more sophisticated use case of property resolution
* provide an API that is convenient to use, that means it assumes defaults that are likely to be intended when resolving configuration values and provides ways to disable individual defaults for untypical use cases

### Default Behaviours
The defaults here are not to throw exception and to never return null or empty `String`.
This should allow to replace `try`-`catch` constructs as well as `if (...isPresent())` constructs to resolve a configuration to the value finally used by the caller. The caller can use methods on the fluent API to opt-out of the defaults one-by-one to adopt the behaviour to the use case.

### Default Values
This support both defaults on the source level (`String`s) as well as typed defaults.
Source level defaults take precedence as they are considered to operate on the source level whereas typed defaults are considered to operate in connection with the later conversion stage. 

### Ad-hoc Conversion
The `asConvertedBy` method for ad-hoc conversion using lambdas intentionally does not use `Converter` type as argument to avoid binding the user to that API and because `Converter`s are required to be `Serializable` which is not needed for ad-hoc conversion.

### API Design Goals
The methods of  `ConfigValueResolver` can be used in any order and even multiple times without leading to conflicting definition. The actual value resolution can only occur once and forces the caller to either provide a default or to work with `Optional`s instead - avoiding exceptions, empty or null values unless intended by the caller.

Naming of the methods has been chosen so that when used fluently the code provides good readability, for example:
```java
// basic case: resolve value with typed default
int val1 = config.getValue("myint").as(Integer.class, 42);
// with empty list default
List<Integer> val2 = config.getValue("mylist").asList(Integer.class);
// or with explicit default
List<Integer> val3 = config.getValue("mylist").asList(Integer.class, Arrays.asList(42));
// same for sets with empty default
Set<Integer> val4 = config.getValue("myset").asSet(Integer.class);
// or explicit default
Set<Integer> val5 = config.getValue("myset").asSet(Integer.class, new HashSet<>(Arrays.asList(42)));

// opt-out of defaults
int val6 = config.getValue("myint").throwOnMissingProperty().as(Integer.class, 42);
int val7 = config.getValue("myint").throwOnFailedConversion().as(Integer.class, 42);
String spacer = config.getValue("spacer").acceptEmpty().as(String.class, ","); // can now be set empty explicitly

// use raw (source) level defaults
List<Integer> val8 = config.getValue("mylist").withDefault(annotation.defaultValue()).asList(Integer.class);
//... and combinations of above and more
```

### API Integration with other APIs and Concepts
I went ahead and removed methods from `Config` which I belief are not yet released and could be covered by the fluent API instead. This would also be the idea for the future that `Config` API is kept cleaner by not having to cover many variants of value resolution. This is extracted to the `ConfigValueResolver` which makes it easier for users to customise the logic of value resolution.

It should also be clear that the `ConfigValueResolver` could be implemented on top of `Config` by vendors or users using API provided by `Config` interface. The intent with adding a `ConfigValueResolver` to the standard is to make user code using such a "convenience API" portable to not lock in users to a vendor API or to build their own API on top of MP Config.

I also added a `withProfile` method to the API mostly to illustrate that this can also be used to handle profiles should those become a features further preventing the need to blur the responsibilities of the `Config` API.

The  `ConfigValueResolver` could even replace the existing `Config.getOptionalValue`; `getOptionalValue("myprop", MyClass.class)` would become `getValue("myprop").as(MyClass.class)`. For better backwards compatibility I left it in but removal could be considered as the replacement is equally short and readable.

This differs from the https://github.com/struberg/microprofile-config/blob/ConfigAccessor/api/src/main/java/org/eclipse/microprofile/config/ConfigAccessor.java API by being a pure convenience API that does not provide new concepts (like snapshots) or adds new capabilities (like caching). While the `ConfigAccessor` is meant to be created "statically" (once) and then be "applied" to an actual `Config` or snapshot the `ConfigValueResolver` is only a utility level on top of the actual `Config` that always needs to be used starting from the current `Config` instance. While the `ConfigAccessor` clearly has its benefits this should be seen as an alternative trying to make the most out of a simpler approach that purely focuses on a more convenient and readable resolution of values. Also keeping in mind that it still holds true, that configurations that are accessed frequently should be buffered by the caller.

Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>