### PR TITLE
Added unwrap API to Config.

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -244,4 +244,19 @@ public interface Config {
      * @return an {@link Optional} containing the converter, or empty if no converter is available for the specified type
      */
     <T> Optional<Converter<T>> getConverter(Class<T> forType);
+
+    /**
+     * Returns an instance of the specific class, to allow access to the provider specific API.
+     * <p>
+     * If the MP Config provider implementation does not support the specified class, a {@link IllegalArgumentException}
+     * is thrown.
+     * <p>
+     * Unwraping to the provider specific API may lead to non-portable behaviour.
+     *
+     * @param type Class representing the type to unwrap to
+     * @param <T> The type to unwrap to
+     * @return An instance of the given type
+     * @throws IllegalArgumentException If the current provider does not support unwrapping to the given type
+     */
+    <T> T unwrap(Class<T> type);
 }


### PR DESCRIPTION
This is a new proposal to add `unwrap` like proposed previously here:

https://github.com/eclipse/microprofile-config/issues/84
https://github.com/eclipse/microprofile-config/pull/85

I believe the use case is there, especially now where we want to experiment more in the implementation side of things.