### PR TITLE
Consistent javadoc formatting

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/config/Config.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/Config.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -29,9 +28,7 @@
  *   2018-04-04 - Mark Struberg, Manfred Huber, Alex Falb, Gerhard Petracek
  *      ConfigSnapshot added. Initially authored in Apache DeltaSpike fdd1e3dcd9a12ceed831dd
  *      Additional reviews and feedback by Tomas Langer.
- *
- *******************************************************************************/
-
+ */
 package org.eclipse.microprofile.config;
 
 import java.lang.reflect.Array;
@@ -43,43 +40,48 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.Converter;
 
 /**
+ * Resolves the property value by searching through all configured {@link ConfigSource ConfigSources}. If the same
+ * property is specified in multiple {@link ConfigSource ConfigSources}, the value in the {@link ConfigSource} with the
+ * highest ordinal will be used.
  * <p>
- * Resolves the property value by searching through all configured
- * {@link ConfigSource ConfigSources}. If the same property is specified in multiple
- * {@link ConfigSource ConfigSources}, the value in the {@link ConfigSource} with the highest
- * ordinal will be used.
- * <p>If multiple {@link ConfigSource ConfigSources} are specified with
- * the same ordinal, the {@link ConfigSource#getName()} will be used for sorting.
+ * If multiple {@link ConfigSource ConfigSources} are specified with the same ordinal, the
+ * {@link ConfigSource#getName()} will be used for sorting.
  * <p>
  * The config objects produced via the injection model {@code @Inject Config} are guaranteed to be serializable, while
  * the programmatically created ones are not required to be serializable.
  * <p>
- * If one or more converters are registered for a class of a requested value then the registered {@link org.eclipse.microprofile.config.spi.Converter}
- * which has the highest {@code @javax.annotation.Priority} is used to convert the string value retrieved from the config sources.
+ * If one or more converters are registered for a class of a requested value then the registered
+ * {@link org.eclipse.microprofile.config.spi.Converter} which has the highest {@code @javax.annotation.Priority} is
+ * used to convert the string value retrieved from the config sources.
  *
  * <h2>Usage</h2>
  *
+ * <p>
  * For accessing the config you can use the {@link ConfigProvider}:
  *
  * <pre>
- * public void doSomething(
+ * public void doSomething() {
  *   Config cfg = ConfigProvider.getConfig();
  *   String archiveUrl = cfg.getValue("my.project.archive.endpoint", String.class);
  *   Integer archivePort = cfg.getValue("my.project.archive.port", Integer.class);
- * </pre>
- *
- * <p>It is also possible to inject the Config if a DI container is available:
- *
- * <pre>
- * public class MyService {
- *     &#064;Inject
- *     private Config config;
  * }
  * </pre>
  *
- * <p>See {@link #getValue(String, Class)} and {@link #getOptionalValue(String, Class)} for accessing a configured value.
+ * <p>
+ * It is also possible to inject the Config if a DI container is available:
  *
- * <p>Configured values can also be accessed via injection.
+ * <pre>
+ * public class MyService {
+ *   &#064;Inject
+ *   private Config config;
+ * }
+ * </pre>
+ *
+ * <p>
+ * See {@link #getValue(String, Class)} and {@link #getOptionalValue(String, Class)} for accessing a configured value.
+ *
+ * <p>
+ * Configured values can also be accessed via injection.
  * See {@link org.eclipse.microprofile.config.inject.ConfigProperty} for more information.
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
@@ -98,12 +100,9 @@ public interface Config {
      * to compute; therefore, if the returned value is intended to be frequently used, callers should consider storing
      * rather than recomputing it.
      *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration property name
-     * @param propertyType
-     *             The type into which the resolved property value should get converted
+     * @param <T> The property type
+     * @param propertyName The configuration property name
+     * @param propertyType The type into which the resolved property value should get converted
      * @return the resolved property value as an instance of the requested type
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
      * @throws java.util.NoSuchElementException if the property isn't present in the configuration
@@ -115,18 +114,15 @@ public interface Config {
      * {@linkplain ConfigSource configuration source}. The lookup of the configuration is performed immediatily,
      * meaning that calls to {@link ConfigValue} will always yeld the same results.
      * <p>
-     *
      * The configuration value is not guaranteed to be cached by the implementation, and may be expensive
      * to compute; therefore, if the returned value is intended to be frequently used, callers should consider storing
      * rather than recomputing it.
      * <p>
-     *
      * A {@link ConfigValue} is always returned even if a property name cannot be found. In this case, every method in
      * {@link ConfigValue} returns {@code null} except for {@link ConfigValue#getName()}, which includes the original
      * property name being looked up.
      *
-     * @param propertyName
-     *              The configuration property name
+     * @param propertyName The configuration property name
      * @return the resolved property value as a {@link ConfigValue}
      */
     ConfigValue getConfigValue(String propertyName);
@@ -139,12 +135,9 @@ public interface Config {
      * to compute; therefore, if the returned values are intended to be frequently used, callers should consider storing
      * rather than recomputing them.
      *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration property name
-     * @param propertyType
-     *             The type into which the resolved property values should get converted
+     * @param <T> The property type
+     * @param propertyName The configuration property name
+     * @param propertyType The type into which the resolved property values should get converted
      * @return the resolved property values as a list of instances of the requested type
      * @throws java.lang.IllegalArgumentException if the property values cannot be converted to the specified type
      * @throws java.util.NoSuchElementException if the property isn't present in the configuration
@@ -162,17 +155,13 @@ public interface Config {
      * The configuration value is not guaranteed to be cached by the implementation, and may be expensive
      * to compute; therefore, if the returned value is intended to be frequently used, callers should consider storing
      * rather than recomputing it.
-     *
+     * <p>
      * If this method is used very often then consider to locally store the configured value.
      *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration property name
-     * @param propertyType
-     *             The type into which the resolved property value should be converted
+     * @param <T> The property type
+     * @param propertyName The configuration property name
+     * @param propertyType The type into which the resolved property value should be converted
      * @return The resolved property value as an {@code Optional} wrapping the requested type
-     *
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
      */
     <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType);
@@ -185,12 +174,9 @@ public interface Config {
      * to compute; therefore, if the returned values are intended to be frequently used, callers should consider storing
      * rather than recomputing them.
      *
-     * @param <T>
-     *             The property type
-     * @param propertyName
-     *             The configuration property name
-     * @param propertyType
-     *             The type into which the resolved property values should be converted
+     * @param <T> The property type
+     * @param propertyName The configuration property name
+     * @param propertyType The type into which the resolved property values should be converted
      * @return The resolved property values as an {@code Optional} wrapping a list of the requested type
      *
      * @throws java.lang.IllegalArgumentException if the property cannot be converted to the specified type
@@ -202,47 +188,55 @@ public interface Config {
     }
 
     /**
-     * Return the resolved configuration properties instance with the specified prefix. 
-     * The type declaration can be annotated with 
-     * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}. 
-     * If the type is annotated with {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}, 
-     * the prefix supplied in this method overrides the prefix associated with the annotation 
+     * Return the resolved configuration properties instance with the specified prefix.
+     * <p>
+     * The type declaration can be annotated with
      * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}.
-     * 
-     * @param <T> 
-     *              The Class Type
+     * <p>
+     * If the type is annotated with
+     * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties},
+     * the prefix supplied in this method overrides the prefix associated with the annotation
+     * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}.
+     *
+     * @param <T> The Class Type
      * @param configProperties
-     *              The class that contains a number of fields that maps to corresponding configuration properties. 
-     *              The type declaration can be annotated with 
+     *              The class that contains a number of fields that maps to corresponding configuration properties.
+     *              The type declaration can be annotated with
      *              {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}.
-     *              The prefix as the method parameter overrides the prefix set on the type.                
+     *              The prefix as the method parameter overrides the prefix set on the type.
      *              This class should contain a zero-arg constructor. Otherwise, non-portable behaviour occurs.
      * @param prefix
      *              The prefix for the configuration properties declared on the class configProperties.
      *              If the prefix is "", which means no prefix involved when performing property lookup.
      *              If the prefix is null, this method is equivalent to {@linkplain #getConfigProperties(Class)}.
-     * @return      An instance for the specified type and prefix 
+     * @return An instance for the specified type and prefix
      */
     <T> T getConfigProperties(Class<T> configProperties, String prefix);
 
     /**
-     * Return the resolved configuration properties instance. The type can be annotated with 
-     * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}. 
-     * If the type is annotated with {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}, 
-     * the prefix associated with the annotation {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties} will be used.
-     * @param <T> 
-     *              The Class Type
+     * Return the resolved configuration properties instance. The type can be annotated with
+     * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}.
+     * <p>
+     * If the type is annotated with
+     * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties},
+     * the prefix associated with the annotation
+     * {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties} will be used.
+     *
+     * @param <T> The Class Type
      * @param configProperties
-     *              The class that contains a number of fields that maps to corresponding configuration properties. 
-     *              The type declaration can be annotated with 
-     *              {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}. 
-     *              If the type is annotated with {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}, 
-     *              the prefix on the annotation {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties} 
-     *              will be honoured. 
-     *              The absence of the annotation {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties} 
-     *              or the absence of the prefix on the annotation means no prefix specified. 
+     *              The class that contains a number of fields that maps to corresponding configuration properties.
+     *              The type declaration can be annotated with
+     *              {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}.
+     *              If the type is annotated with
+     *              {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties},
+     *              the prefix on the annotation
+     *              {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}
+     *              will be used.
+     *              The absence of the annotation
+     *              {@linkplain org.eclipse.microprofile.config.inject.ConfigProperties @ConfigProperties}
+     *              or the absence of the prefix on the annotation means no prefix specified.
      *              This class should contain a zero-arg constructor. Otherwise, non-portable behaviour occurs.
-     * @return      An instance for the specified type
+     * @return An instance for the specified type
      */
     <T> T getConfigProperties(Class<T> configProperties);
 
@@ -264,16 +258,17 @@ public interface Config {
      * {@link java.util.Iterator Iterator} must adhere to the contract of that class, and must not return any more
      * elements once its {@link java.util.Iterator#hasNext() hasNext()} method returns {@code false}.
      * <p>
-     * The returned instance is thread safe and may be iterated concurrently.  The individual iterators are not
+     * The returned instance is thread safe and may be iterated concurrently. The individual iterators are not
      * thread-safe.
      *
-     * @return the names of all configured keys of the underlying configuration.
+     * @return the names of all configured keys of the underlying configuration
      */
     Iterable<String> getPropertyNames();
 
     /**
      * Return all of the currently registered {@linkplain ConfigSource configuration sources} for this configuration.
-     * The returned sources will be sorted by descending ordinal value and name, which can be iterated in a thread-safe manner.
+     * The returned sources will be sorted by descending ordinal value and name, which can be iterated in a thread-safe
+     * manner.
      *
      * @return the configuration sources
      */
@@ -282,11 +277,10 @@ public interface Config {
     /**
      * Return the {@link Converter} used by this instance to produce instances of the specified type from string values.
      *
-     * @param <T>
-     *             the conversion type
-     * @param forType
-     *             the type to be produced by the converter
-     * @return an {@link Optional} containing the converter, or empty if no converter is available for the specified type
+     * @param <T> the conversion type
+     * @param forType the type to be produced by the converter
+     * @return an {@link Optional} containing the converter, or empty if no converter is available for the specified
+     * type
      */
     <T> Optional<Converter<T>> getConverter(Class<T> forType);
 

--- a/api/src/main/java/org/eclipse/microprofile/config/ConfigProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/ConfigProvider.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -26,43 +25,39 @@
  *      SPI reworked into own ConfigProviderResolver
  *   2016-12-02 - Viktor Klang
  *      removed ConfigFilter and security related functionality.
- *
- *******************************************************************************/
-
+ */
 package org.eclipse.microprofile.config;
 
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 
 /**
- * <p>
  * This is the central class to access a {@link Config}.
- * A {@link Config} provides access to the application's configuration.
- * It may have been automatically discovered, or manually created and registered.
- *
+ * <p>
+ * A {@link Config} provides access to the application's configuration. It may have been automatically discovered, or
+ * manually created and registered.
  * <p>
  * The default usage is to use {@link #getConfig()} to automatically pick up the
  * <em>configuration</em> for the current thread's {@linkplain Thread#getContextClassLoader() context class loader}.
- *
  * <p>
  * A <em>configuration</em> consists of information collected from the registered
- * <em>{@linkplain org.eclipse.microprofile.config.spi.ConfigSource configuration sources}</em>, combined with the set of
- * registered {@linkplain org.eclipse.microprofile.config.spi.Converter converters}.
+ * <em>{@linkplain org.eclipse.microprofile.config.spi.ConfigSource configuration sources}</em>, combined with the set
+ * of registered {@linkplain org.eclipse.microprofile.config.spi.Converter converters}.
  * The <em>configuration sources</em> get sorted according to their
  * <em>{@linkplain org.eclipse.microprofile.config.spi.ConfigSource#getOrdinal() ordinal value}</em>.
  * Thus it is possible to override a lower-priority <em>configuration source</em> with a higher-priority one.
- *
  * <p>
  * It is also possible to register custom <em>configuration sources</em> to flexibly
  * extend the configuration mechanism. For example, a configuration source could be provided which reads
  * configuration values from a database table.
- * <p>
- * Example usage:
  *
+ * <p>
+ * Example:
  * <pre>
  * String restUrl = ConfigProvider.getConfig().getValue(&quot;myproject.some.remote.service.url&quot;, String.class);
  * Integer port = ConfigProvider.getConfig().getValue(&quot;myproject.some.remote.service.port&quot;, Integer.class);
  * </pre>
  *
+ * <p>
  * For more advanced use cases (e.g. registering a manually created {@link Config} instance), please see
  * {@link ConfigProviderResolver#registerConfig(Config, ClassLoader)} and {@link ConfigProviderResolver#getBuilder()}.
  *
@@ -72,7 +67,6 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
  * @author <a href="mailto:viktor.klang@gmail.com">Viktor Klang</a>
  */
 public final class ConfigProvider {
-
     private ConfigProvider() {
     }
 
@@ -99,6 +93,7 @@ public final class ConfigProvider {
      * <p>
      * Each class loader corresponds to exactly one configuration.
      *
+     * @param cl the Classloader used to register the configuration instance
      * @return the configuration instance for the given class loader
      */
     public static Config getConfig(ClassLoader cl) {

--- a/api/src/main/java/org/eclipse/microprofile/config/ConfigValue.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/ConfigValue.java
@@ -15,21 +15,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 package org.eclipse.microprofile.config;
 
 /**
  * The ConfigValue holds additional information after the lookup of a configuration property and is itself immutable.
  * <p>
- *
  * Holds information about the configuration property name, configuration value, the
  * {@link org.eclipse.microprofile.config.spi.ConfigSource} name from where the configuration property was loaded and
  * the ordinal of the {@link org.eclipse.microprofile.config.spi.ConfigSource}.
  * <p>
- *
  * This is used together with {@link Config} to expose the configuration property lookup metadata.
  *
+ * @since 2.0
  * @author <a href="mailto:radcortez@yahoo.com">Roberto Cortez</a>
  */
 public interface ConfigValue {
@@ -43,14 +41,14 @@ public interface ConfigValue {
     /**
      * The value of the property lookup.
      *
-     * @return the raw value of the property lookup or {@code null} if the property could not be found.
+     * @return the raw value of the property lookup or {@code null} if the property could not be found
      */
     String getValue();
 
     /**
      * The {@link org.eclipse.microprofile.config.spi.ConfigSource} name that loaded the property lookup.
      *
-     * @return the ConfigSource name that loaded the property lookup or {@code null} if the property could not be found.
+     * @return the ConfigSource name that loaded the property lookup or {@code null} if the property could not be found
      */
     String getSourceName();
 
@@ -58,7 +56,7 @@ public interface ConfigValue {
      * The {@link org.eclipse.microprofile.config.spi.ConfigSource} ordinal that loaded the property lookup.
      *
      * @return the ConfigSource ordinal that loaded the property lookup or {@code 0} if the property could not be
-     * found.
+     * found
      */
     int getSourceOrdinal();
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperties.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperties.java
@@ -16,9 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.eclipse.microprofile.config.inject;
-
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.ElementType.METHOD;
@@ -35,35 +33,36 @@ import javax.enterprise.util.Nonbinding;
 import javax.inject.Qualifier;
 
 /**
- * 
  * Retrieve a number of related configuration properties with the specified prefix into a property class.
  * This class should contain a zero-arg constructor. Otherwise, non-portable behaviour occurs.
+ *
+ * <h2>Example</h2>
+ *
  * <pre>
  * &#064;ConfigProperties(prefix="server")
  * public class MyServer {
- *      public String host; //maps the property name server.host
- *      public int port;    //maps to the property name server.port
- *      private String context; //maps to the property name server.context
- *      public &#064;ConfigProperty(name="old.location")
- *      String location; //maps to the property name server.old.location
- *      public String getContext() {
- *          return context;
- *      }
+ *   public String host;     //maps the property name server.host
+ *   public int port;        //maps to the property name server.port
+ *   private String context; //maps to the property name server.context
+ *   &#064;ConfigProperty(name="old.location")
+ *   public String location; //maps to the property name server.old.location
+ *   public String getContext() {
+ *     return context;
+ *   }
  * }
  * </pre>
+ *
  * @since 2.0
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
- * 
  */
-
 @Target({METHOD, FIELD, PARAMETER, TYPE})
 @Retention(RUNTIME)
 @Documented
 @Qualifier
 public @interface ConfigProperties {
-
     /**
-     * The prefix of the configuration properties
+     * The prefix of the configuration properties.
+     *
      * @return the configuration property prefix
      */
     @Nonbinding
@@ -73,8 +72,7 @@ public @interface ConfigProperties {
      * Support inline instantiation of the {@link ConfigProperties} qualifier.
      */
     public final static class Literal extends AnnotationLiteral<ConfigProperties> implements ConfigProperties {
-
-        public static final Literal NOPREFIX = of(""); 
+        public static final Literal NOPREFIX = of("");
 
         private static final long serialVersionUID = 1L;
         private final String prefix;
@@ -91,6 +89,5 @@ public @interface ConfigProperties {
         public String prefix() {
             return prefix;
         }
-
     }
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.eclipse.microprofile.config.inject;
 
 import static java.lang.annotation.ElementType.FIELD;
@@ -36,46 +35,53 @@ import javax.inject.Qualifier;
 import org.osgi.annotation.bundle.Requirement;
 
 /**
- * <p>
  * Binds the injection point with a configured value.
- * Can be used to annotate injection points of type {@code TYPE}, {@code Optional<TYPE>} or {@code javax.inject.Provider<TYPE>},
- * where {@code TYPE} can be {@code String} and all types which have appropriate converters.
  * <p>
- * Injected values are the same values that would be retrieved from an injected {@link org.eclipse.microprofile.config.Config} instance
- * or from the instance retrieved from {@link org.eclipse.microprofile.config.ConfigProvider#getConfig()}
+ * Can be used to annotate injection points of type {@code TYPE}, {@code Optional<TYPE>} or
+ * {@code javax.inject.Provider<TYPE>}, where {@code TYPE} can be {@code String} and all types which have appropriate
+ * converters.
+ * <p>
+ * Injected values are the same values that would be retrieved from an injected
+ * {@link org.eclipse.microprofile.config.Config} instance or from the instance retrieved from
+ * {@link org.eclipse.microprofile.config.ConfigProvider#getConfig()}
  *
  * <h2>Examples</h2>
  *
  * <h3>Injecting Native Values</h3>
  *
- * The first sample injects the configured value of the {@code my.long.property} property.
- * The injected value does not change even if the underline
- * property value changes in the {@link org.eclipse.microprofile.config.Config}.
+ * <p>
+ * The first sample injects the configured value of the {@code my.long.property} property. The injected value does not
+ * change even if the underline property value changes in the {@link org.eclipse.microprofile.config.Config}.
+ * <p>
+ * Injecting a native value is recommended for a mandatory property and its value does not change at runtime or used by
+ * a bean with RequestScoped.
+ * <p>
+ * A further recommendation is to use the built in {@code META-INF/microprofile-config.properties} file mechanism
+ * to provide default values inside an Application. If no configured value exists for this property, a
+ * {@code DeploymentException} will be thrown during startup.
  *
- * <p>Injecting a native value is recommended for a mandatory property and its value does not change at runtime or used by a bean with RequestScoped.
- * <p>A further recommendation is to use the built in {@code META-INF/microprofile-config.properties} file mechanism
- * to provide default values inside an Application.
- * If no configured value exists for this property, a {@code DeploymentException} will be thrown during startup.
  * <pre>
  * &#064;Inject
  * &#064;ConfigProperty(name="my.long.property")
  * private Long injectedLongValue;
  * </pre>
  *
- *
  * <h3>Injecting Optional Values</h3>
  *
- *
+ * <p>
  * Contrary to natively injecting, if the property is not specified, this will not lead to a DeploymentException.
- * The following code injects a Long value to the {@code my.optional.long.property}.
- * If the property does not exist, the value {@code 123} will be assigned.
- * to {@code injectedLongValue}.
+ * The following code injects a Long value to the {@code my.optional.long.property}. If the property does not exist,
+ * the value {@code 123} will be assigned. to {@code injectedLongValue}.
+ *
  * <pre>
  * &#064;Inject
  * &#064;ConfigProperty(name="my.optional.long.property", defaultValue="123")
  * private Long injectedLongValue;
  * </pre>
+ *
+ * <p>
  * The following code injects an Optional value of {@code my.optional.int.property}.
+ *
  * <pre>
  * &#064;Inject
  * &#064;ConfigProperty(name = "my.optional.int.property")
@@ -84,17 +90,20 @@ import org.osgi.annotation.bundle.Requirement;
  *
  * <h3>Injecting Dynamic Values</h3>
  *
- * The next sample injects a Provider for the value of {@code my.long.property} property to resolve the property dynamically.
- * Each invocation to {@code Provider#get()} will resolve the latest value from underlying {@link org.eclipse.microprofile.config.Config} again.
- * The existence of configured values will get checked during startup.
- * Instances of {@code Provider<T>} are guaranteed to be Serializable.
+ * <p>
+ * The next sample injects a Provider for the value of {@code my.long.property} property to resolve the property
+ * dynamically. Each invocation to {@code Provider#get()} will resolve the latest value from underlying
+ * {@link org.eclipse.microprofile.config.Config} again. The existence of configured values will get checked during
+ * startup. Instances of {@code Provider<T>} are guaranteed to be Serializable.
+ *
  * <pre>
  * &#064;Inject
  * &#064;ConfigProperty(name = "my.long.property" defaultValue="123")
  * private Provider&lt;Long&gt; longConfigValue;
  * </pre>
  *
- * <p>If {@code ConfigProperty} is used with a type where no {@link org.eclipse.microprofile.config.spi.Converter} exists,
+ * <p>
+ * If {@code ConfigProperty} is used with a type where no {@link org.eclipse.microprofile.config.spi.Converter} exists,
  * a deployment error will be thrown.
  *
  * @author Ondrej Mihalyi
@@ -117,10 +126,13 @@ public @interface ConfigProperty {
     String UNCONFIGURED_VALUE="org.eclipse.microprofile.config.configproperty.unconfigureddvalue";
     /**
      * The key of the config property used to look up the configuration value.
+     * <p>
      * If it is not specified, it will be derived automatically as {@code <class_name>.<injection_point_name>},
-     * where {@code injection_point_name} is the field name or parameter name,
-     * {@code class_name} is the fully qualified name of the class being injected to.
-     * If one of the {@code class_name} or {@code injection_point_name} cannot be determined, the value has to be provided.
+     * where {@code injection_point_name} is the field name or parameter name, {@code class_name} is the fully
+     * qualified name of the class being injected to.
+     * <p>
+     * If one of the {@code class_name} or {@code injection_point_name} cannot be determined, the value has to be
+     * provided.
      *
      * @return Name (key) of the config property to inject
      */
@@ -128,11 +140,10 @@ public @interface ConfigProperty {
     String name() default "";
 
     /**
-     * <p>The default value if the configured property value does not exist.
-     *
-     * <p>If the target Type is not String a proper {@link org.eclipse.microprofile.config.spi.Converter} will get applied.
+     * The default value if the configured property value does not exist.
+     * <p>
+     * If the target Type is not String a proper {@link org.eclipse.microprofile.config.spi.Converter} will get applied.
      * That means that any default value string should follow the formatting rules of the registered Converters.
-     *
      *
      * @return the default value as a string
      */

--- a/api/src/main/java/org/eclipse/microprofile/config/inject/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/inject/package-info.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,35 +15,35 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 
 /**
- * <p>CDI Support for Microprofile Config
+ * CDI Support for MicroProfile Config
  *
- * <p>Microprofile Config also supports injection via a JSR-330 DI container:
+ * <p>
+ * MicroProfile Config also supports injection via a JSR-330 DI container:
+ *
  * <pre>
  *  &#064;Inject
  *  &#064;ConfigProperty(name="myproject.some.endpoint.url");
  *  private String restUrl;
  * </pre>
  *
- * <p>The following types can be injected:
- * <ul>
+ * <p>
+ * The following types can be injected:
  *
- *     <li><code>T</code> where T is a Type where a {@link org.eclipse.microprofile.config.spi.Converter} exists and the property must exist.</li>
- *     <li><code>
- *     Optional&lt;T&gt;</code> where T is a Type where a {@link org.eclipse.microprofile.config.spi.Converter} exists where the property may exist.
- *     </li>
- *     <li><code>
- *     Provider&lt;T&gt;</code> where T is a Type where a {@link org.eclipse.microprofile.config.spi.Converter} exists where the property may exist.
- *     </li>
+ * <ul>
+ *   <li><code>T</code> where T is a Type where a {@link org.eclipse.microprofile.config.spi.Converter} exists and the
+ *   property must exist.</li>
+ *   <li><code>Optional&lt;T&gt;</code> where T is a Type where a
+ *   {@link org.eclipse.microprofile.config.spi.Converter} exists where the property may exist.</li>
+ *   <li><code>Provider&lt;T&gt;</code> where T is a Type where a
+ *   {@link org.eclipse.microprofile.config.spi.Converter} exists where the property may exist. </li>
  * </ul>
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
- *
  */
-
 @org.osgi.annotation.versioning.Version("1.1")
 package org.eclipse.microprofile.config.inject;
 

--- a/api/src/main/java/org/eclipse/microprofile/config/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/package-info.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,24 +15,27 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 
 /**
- * <p>Configuration for Java Microprofile
+ * Configuration for Java MicroProfile
  *
  * <h2>Rationale</h2>
  *
- * <p>For many project artifacts (e.g. WAR, EAR) it should be possible to build them only once
+ * <p>
+ * For many project artifacts (e.g. WAR, EAR) it should be possible to build them only once
  * and then install them at different customers, stages, etc.
  * They need to target those different execution environments without the necessity of any repackaging.
  * In other words: depending on the situation they need different configuration.
  *
- * <p>This is easily achievable by having a set of default configuration values inside the project artifact.
+ * <p>
+ * This is easily achievable by having a set of default configuration values inside the project artifact.
  * But be able to overwrite those default values from external.
  *
  * <h2>How it works</h2>
  *
- * <p>A 'Configuration' consists of the information collected from the registered
+ * <p>
+ * A <em>Configuration</em> consists of the information collected from the registered
  * {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources}.
  * These {@code ConfigSources} get sorted according to their <i>ordinal</i>.
  * That way it is possible to overwrite configuration with lower importance from outside.
@@ -41,40 +43,45 @@
  * <p>By default there are 3 ConfigSources:
  *
  * <ul>
- * <li>{@code System.getProperties()} (ordinal=400)</li>
- * <li>{@code System.getenv()} (ordinal=300)</li>
- * <li>all {@code META-INF/microprofile-config.properties} files on the ClassPath.
- *  (ordinal=100, separately configurable via a config_ordinal property inside each file)</li>
+ *   <li>{@code System.getProperties()} (ordinal=400)</li>
+ *   <li>{@code System.getenv()} (ordinal=300)</li>
+ *   <li>all {@code META-INF/microprofile-config.properties} files on the ClassPath.
+ *    (ordinal=100, separately configurable via a config_ordinal property inside each file)</li>
  * </ul>
  *
- * <p>That means that one can put the default configuration in a {@code META-INF/microprofile-config.properties} anywhere on the classpath.
- * and the Operations team can later simply e.g set a system property to change this default configuration.
+ * <p>
+ * That means that one can put the default configuration in a {@code META-INF/microprofile-config.properties} anywhere
+ * on the classpath and the Operations team can later simply e.g set a system property to change this default
+ * configuration.
  *
- * <p>It is of course also possible to register own {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources}.
+ * <p>
+ * It is of course also possible to register own {@link org.eclipse.microprofile.config.spi.ConfigSource ConfigSources}.
  * A {@code ConfigSource} could e.g. read configuration values from a database table, a remote server, etc
  *
- *  <h2>Accessing and Using the Configuration</h2>
+ * <h2>Accessing and Using the Configuration</h2>
  *
- *  <p> The configuration of an application is represented by an instance of {@link org.eclipse.microprofile.config.Config}.
- *  The {@link org.eclipse.microprofile.config.Config} can be accessed via the {@link org.eclipse.microprofile.config.ConfigProvider}.
+ * <p>
+ * The configuration of an application is represented by an instance of {@link org.eclipse.microprofile.config.Config}.
+ * The {@link org.eclipse.microprofile.config.Config} can be accessed via the
+ * {@link org.eclipse.microprofile.config.ConfigProvider}.
  *
- *  <pre>
- *  Config config = ConfigProvider.getConfig();
- *  String restUrl = config.getValue("myproject.some.endpoint.url", String.class);
- *  </pre>
+ * <pre>
+ * Config config = ConfigProvider.getConfig();
+ * String restUrl = config.getValue("myproject.some.endpoint.url", String.class);
+ * </pre>
  *
- *  <p> Of course we also support injection via a JSR-330 DI container:
- *  <pre>
- *  &#064;Inject
- *  &#064;ConfigProperty(name="myproject.some.endpoint.url");
- *  private String restUrl;
- *  </pre>
+ * <p>
+ * Injection via a JSR-330 DI container is also supported:
+ *
+ * <pre>
+ * &#064;Inject
+ * &#064;ConfigProperty(name="myproject.some.endpoint.url");
+ * private String restUrl;
+ * </pre>
  *
  * @author <a href="emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
- *
  */
-
 @org.osgi.annotation.versioning.Version("2.0.0")
 package org.eclipse.microprofile.config;
 

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigBuilder.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -24,8 +23,7 @@
  *      Merged and JavaDoc          c8525998a43fe798f367
  *   2016-11-14 - Emily Jiang / IBM
  *      API improvements + JavaDoc  f53258b8eca1253fee52
- *
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.config.spi;
 
 import org.eclipse.microprofile.config.Config;
@@ -84,7 +82,7 @@ public interface ConfigBuilder {
     /**
      * Add the specified {@link Converter} instances to the configuration being built.
      * <p>
-     * The implementation may use reflection to determine the target type of the converter.  If the
+     * The implementation may use reflection to determine the target type of the converter. If the
      * type cannot be determined reflectively, this method may fail with a runtime exception.
      * <p>
      * When using lambda expressions for custom converters you should use the
@@ -114,7 +112,7 @@ public interface ConfigBuilder {
      * @return this configuration builder instance
      */
     <T> ConfigBuilder withConverter(Class<T> type, int priority, Converter<T> converter);
-    
+
     /**
      * Build a new {@link Config} instance based on this builder instance.
      *

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigProviderResolver.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigProviderResolver.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2016-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
-
+ */
 package org.eclipse.microprofile.config.spi;
 
 import java.util.Iterator;
@@ -69,6 +67,7 @@ public abstract class ConfigProviderResolver {
      * Get the configuration instance for the current application in the manner described by
      * {@link org.eclipse.microprofile.config.ConfigProvider#getConfig(ClassLoader)}.
      *
+     * @param loader the class loader identifying the application
      * @return the configuration instance
      */
     public abstract Config getConfig(ClassLoader loader);
@@ -92,7 +91,6 @@ public abstract class ConfigProviderResolver {
      *
      * @param config the configuration to register
      * @param classLoader the class loader identifying the application
-     *
      * @throws IllegalStateException if there is already a configuration registered for the application
      */
     public abstract void registerConfig(Config config, ClassLoader classLoader);
@@ -107,8 +105,8 @@ public abstract class ConfigProviderResolver {
     public abstract void releaseConfig(Config config);
 
     /**
-     * Find and return the provider resolver instance.  If the provider resolver instance was already found,
-     * or was manually specified, that instance is returned.  Otherwise, {@link ServiceLoader} is used to
+     * Find and return the provider resolver instance. If the provider resolver instance was already found,
+     * or was manually specified, that instance is returned. Otherwise, {@link ServiceLoader} is used to
      * locate the first implementation that is visible from the class loader that defined this class.
      *
      * @return the provider resolver instance
@@ -125,7 +123,6 @@ public abstract class ConfigProviderResolver {
 
         return instance;
     }
-
 
     private static ConfigProviderResolver loadSpi(ClassLoader cl) {
         ServiceLoader<ConfigProviderResolver> sl = ServiceLoader.load(
@@ -144,7 +141,7 @@ public abstract class ConfigProviderResolver {
      * pattern.
      * <p>
      * Note that calling this method after a different provider instance was {@linkplain #instance() already retrieved}
-     * can lead to inconsistent results.  Mixing usage of this method with the service loader
+     * can lead to inconsistent results. Mixing usage of this method with the service loader
      * pattern is for this reason strongly discouraged.
      *
      * @param resolver the instance to set, or {@code null} to unset the instance

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java
@@ -1,5 +1,4 @@
 /*
- ******************************************************************************
  * Copyright (c) 2009-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -24,8 +23,7 @@
  *      Contributed to Apache DeltaSpike fb0131106481f0b9a8fd
  *   2016-11-14 - Emily Jiang / IBM Corp
  *      Methods renamed, JavaDoc and cleanup
- *
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.config.spi;
 
 import java.util.HashMap;
@@ -33,60 +31,74 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * A <em>configuration source</em> which provides configuration values from a specific place.  Some examples of configuration
- * sources may include:
+ * A <em>configuration source</em> which provides configuration values from a specific place. Some examples of
+ * configuration sources may include:
+ *
  * <ul>
- *     <li>a JNDI-backed naming service</li>
- *     <li>a properties file</li>
- *     <li>a database table</li>
+ *   <li>a JNDI-backed naming service</li>
+ *   <li>a properties file</li>
+ *   <li>a database table</li>
  * </ul>
+ *
+ * <p>
  * Implementations of this interface have the responsibility to get the value corresponding to a property name, and to
  * enumerate available property names.
  * <p>
- * A <em>configuration source</em> is always read-only; any potential updates of the backing configuration values must be handled
- * directly inside each configuration source instance.
+ * A <em>configuration source</em> is always read-only; any potential updates of the backing configuration values must
+ * be handled directly inside each configuration source instance.
  *
  * <h2 id="default_config_sources">Default configuration sources</h2>
- * Some configuration sources are known as <em>default configuration sources</em>.  These configuration sources are
+ *
+ * <p>
+ * Some configuration sources are known as <em>default configuration sources</em>. These configuration sources are
  * normally available in all automatically-created configurations, and can be
- * {@linkplain ConfigBuilder#addDefaultSources() manually added} to manually-created configurations as well.  The
+ * {@linkplain ConfigBuilder#addDefaultSources() manually added} to manually-created configurations as well. The
  * default configuration sources are:
+ *
  * <ol>
- * <li>{@linkplain System#getProperties() System properties}, with an {@linkplain #getOrdinal() ordinal value} of {@code 400}</li>
- * <li>{@linkplain System#getenv() Environment properties}, with an ordinal value of {@code 300}</li>
- * <li>The {@code /META-INF/microprofile-config.properties} {@linkplain ClassLoader#getResource(String) resource},
- * with an ordinal value of {@code 100}</li>
+ *   <li>{@linkplain System#getProperties() System properties}, with an {@linkplain #getOrdinal() ordinal value} of
+ *   {@code 400}</li>
+ *   <li>{@linkplain System#getenv() Environment properties}, with an ordinal value of {@code 300}</li>
+ *   <li>The {@code /META-INF/microprofile-config.properties} {@linkplain ClassLoader#getResource(String) resource},
+ *   with an ordinal value of {@code 100}</li>
  * </ol>
  *
  * <h3>Environment variable name mapping rules</h3>
  *
- * <p>Some operating systems allow only alphabetic characters or an underscore ({@code _}) in environment variable names.
+ * <p>
+ * Some operating systems allow only alphabetic characters or an underscore ({@code _}) in environment variable names.
  * Other characters such as {@code .}, {@code /}, etc. may be disallowed. In order to set a value for a config property
  * that has a name containing such disallowed characters from an environment variable, the following rules are used.
+ *
+ * <p>
  * Three environment variables are searched for a given property name (e.g. "{@code com.ACME.size}"):
- *        <ol>
- *            <li>The exact name (i.e. "{@code com.ACME.size}")</li>
- *            <li>The name, with each character that is neither alphanumeric nor _ replaced with _ (i.e. "{@code com_ACME_size}")</li>
- *            <li>The name, with each character that is neither alphanumeric nor _ replaced with _ and then converted to upper case
- * (i.e. "{@code COM_ACME_SIZE}")</li>
- *        </ol>
- *    <p>The first of these environment variables that is found for a given name is returned.
+ * <ol>
+ *   <li>The exact name (i.e. "{@code com.ACME.size}")</li>
+ *   <li>The name, with each character that is neither alphanumeric nor _ replaced with _
+ *   (i.e. "{@code com_ACME_size}")</li>
+ *   <li>The name, with each character that is neither alphanumeric nor _ replaced with _ and then converted to upper
+ *   case (i.e. "{@code COM_ACME_SIZE}")</li>
+ * </ol>
+ *
+ * <p>
+ * The first of these environment variables that is found for a given name is returned.
  *
  * <h3 id="discovery">Configuration source discovery</h3>
  *
- * <p>Discovered configuration sources are loaded via the {@link java.util.ServiceLoader} mechanism and and can be registered by
- * providing a resource named {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource},
+ * <p>
+ * Discovered configuration sources are loaded via the {@link java.util.ServiceLoader} mechanism and and can be
+ * registered by providing a resource named {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource},
  * which contains the fully qualified {@code ConfigSource} implementation class name as its content.
  *
- * <p>Configuration sources may also be added by defining
+ * <p>
+ * Configuration sources may also be added by defining
  * {@link org.eclipse.microprofile.config.spi.ConfigSourceProvider} classes which are discoverable in this manner.
  *
- * <p>
  * <h3>Closing configuration sources</h3>
  *
- * <p>If a configuration source implements the {@link AutoCloseable} interface,
- * then its {@linkplain AutoCloseable#close() close method} will be called when
- * the underlying configuration is released.
+ * <p>
+ * If a configuration source implements the {@link AutoCloseable} interface, then its
+ * {@linkplain AutoCloseable#close() close method} will be called when the underlying configuration is released.
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
@@ -111,15 +123,14 @@ public interface ConfigSource {
      */
     default Map<String, String> getProperties() {
         Map<String, String> props = new HashMap<>();
-        getPropertyNames().stream().forEach((prop) -> props.put(prop, getValue(prop)));
+        getPropertyNames().forEach((prop) -> props.put(prop, getValue(prop)));
         return props;
     }
 
-
-
     /**
      * Gets all property names known to this configuration source, potentially without evaluating the values.
-     * The returned property names may be a subset of the names of the total set of retrievable properties in this config source.
+     * The returned property names may be a subset of the names of the total set of retrievable properties in this
+     * config source.
      * <p>
      * The returned set is not required to allow concurrent or multi-threaded iteration; however, if the same set is
      * returned by multiple calls to this method, then the implementation must support concurrent and multi-threaded
@@ -134,23 +145,24 @@ public interface ConfigSource {
 
     /**
      * Return the ordinal priority value of this configuration source.
+     * <p>
      * If a property is specified in multiple config sources, the value in the config source with the highest ordinal
-     * takes precedence.
-     * For configuration sources with the same ordinal value, the configuration source name will
+     * takes precedence. For configuration sources with the same ordinal value, the configuration source name will
      * be used for sorting according to string sorting criteria.
      * <p>
      * Note that this method is only evaluated during the construction of the configuration, and does not affect
      * the ordering of configuration sources within a configuration after that time.
      * <p>
-     * The ordinal values for the default configuration sources can be found <a href="#default_config_sources">above</a>.
+     * The ordinal values for the default configuration sources can be found
+     * <a href="#default_config_sources">above</a>.
      * <p>
      * Any configuration source which is a part of an application will typically use an ordinal between 0 and 200.
      * Configuration sources provided by the container or 'environment' typically use an ordinal higher than 200.
      * A framework which intends have values overridden by the application will use ordinals between 0 and 100.
      * <p>
-     * The default implementation of this method looks for a configuration property named "{@link #CONFIG_ORDINAL config_ordinal}"
-     * to determine the ordinal value for this configuration source.  If the property is not found, then the
-     * {@linkplain #DEFAULT_ORDINAL default ordinal value} is used.
+     * The default implementation of this method looks for a configuration property named
+     * "{@link #CONFIG_ORDINAL config_ordinal}" to determine the ordinal value for this configuration source. If the
+     * property is not found, then the {@linkplain #DEFAULT_ORDINAL default ordinal value} is used.
      * <p>
      * This method may be overridden by configuration source implementations to provide a different behavior.
      *
@@ -178,7 +190,7 @@ public interface ConfigSource {
     String getValue(String propertyName);
 
     /**
-     * The name of the configuration source.  The name might be used for logging or for analysis of configured values,
+     * The name of the configuration source. The name might be used for logging or for analysis of configured values,
      * and also may be used in {@linkplain #getOrdinal() ordering decisions}.
      * <p>
      * An example of a configuration source name is "{@code property-file mylocation/myprops.properties}".
@@ -186,5 +198,4 @@ public interface ConfigSource {
      * @return the name of the configuration source
      */
     String getName();
-
 }

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSourceProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSourceProvider.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -24,9 +23,7 @@
  *      Extracted the Config part out of Apache DeltaSpike and proposed as Microprofile-Config
  *   2016-11-14 - Emily Jiang / IBM Corp
  *      Methods renamed, JavaDoc and cleanup
- *
- *******************************************************************************/
-
+ */
 package org.eclipse.microprofile.config.spi;
 
 /**
@@ -38,18 +35,16 @@ package org.eclipse.microprofile.config.spi;
  * Instances of this interface will be {@linkplain ConfigBuilder#addDiscoveredSources() discovered} via the
  * {@link java.util.ServiceLoader} mechanism and can be registered by providing a
  * {@code META-INF/services/org.eclipse.microprofile.config.spi.ConfigSourceProvider}
- * {@linkplain ClassLoader#getResource(String) resource} which contains
- * the fully qualified class name of the custom {@code ConfigSourceProvider} implementation.
+ * {@linkplain ClassLoader#getResource(String) resource} which contains the fully qualified class name of the custom
+ * {@code ConfigSourceProvider} implementation.
  *
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  * @author <a href="mailto:gpetracek@apache.org">Gerhard Petracek</a>
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
- *
  */
 public interface ConfigSourceProvider {
-
     /**
-     * Return the {@link ConfigSource} instances that are provided by this provider.  An empty {@code Iterable} may
+     * Return the {@link ConfigSource} instances that are provided by this provider. An empty {@code Iterable} may
      * be returned if no sources are to be provided.
      *
      * @param forClassLoader the class loader which should be used for discovery and resource loading purposes

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java
@@ -1,5 +1,4 @@
 /*
- ********************************************************************************
  * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -24,95 +23,104 @@
  *      JavaDoc + priority
  *   2016-12-01 - Emily Jiang / IBM Corp
  *      Marking as FunctionalInterface + JavaDoc + additional types
- *
- *******************************************************************************/
-
+ */
 package org.eclipse.microprofile.config.spi;
 
 import java.io.Serializable;
 
 /**
- * <p>
  * A mechanism for converting configured values from {@link String} to any Java type.
  *
  * <h2 id="global_converters">Global converters</h2>
  *
- * Converters may be global to a {@code Config} instance.  Global converters are registered
- * either by being <a href="#discovery">discovered</a> or explicitly
- * {@linkplain ConfigBuilder#withConverter(Class, int, Converter) added to the configuration}.
+ * <p>
+ * Converters may be global to a {@code Config} instance. Global converters are registered either by being
+ * <a href="#discovery">discovered</a> or explicitly {@linkplain ConfigBuilder#withConverter(Class, int, Converter)
+ * added to the configuration}.
  * <p>
  * Global converters are automatically applied to types that match the converter's type.
  *
  * <h3 id="built_in_converters">Built-in converters</h3>
  *
- * Global converters may be <em>built in</em>.  Such converters are provided by the implementation.  A
- * compliant implementation must provide build-in converters for <em>at least</em> the following types:
+ * <p>
+ * Global converters may be <em>built in</em>. Such converters are provided by the implementation. A compliant
+ * implementation must provide build-in converters for <em>at least</em> the following types:
  * <ul>
- *     <li>{@code boolean} and {@code Boolean}, returning {@code true} for at least the following values (case insensitive):
- *     <ul>
- *         <li>{@code true}</li>
- *         <li>{@code yes}</li>
- *         <li>{@code y}</li>
- *         <li>{@code on}</li>
- *         <li>{@code 1}</li>
- *     </ul>
- *     <li>{@code byte} and {@code Byte}, accepting (at minimum) all values accepted by the {@link Byte#parseByte(String)} method</li>
- *     <li>{@code short} and {@code Short}, accepting (at minimum) all values accepted by the {@link Byte#parseByte(String)} method</li>
- *     <li>{@code int}, {@code Integer}, and {@code OptionalInt} accepting (at minimum) all values accepted by the {@link Integer#parseInt(String)}
- *     method</li>
- *     <li>{@code long}, {@code Long}, and {@code OptionalLong} accepting (at minimum) all values accepted by the {@link Long#parseLong(String)}
- *     method</li>
- *     <li>{@code float} and {@code Float}, accepting (at minimum) all values accepted by the {@link Float#parseFloat(String)} method</li>
- *     <li>{@code double}, {@code Double}, and {@code OptionalDouble} accepting (at minimum) all values accepted by the
- *     {@link Double#parseDouble(String)} method</li>
- *     <li>{@code java.lang.Class} based on the result of {@link java.lang.Class#forName}</li>
- *     <li>{@code java.lang.String}</li>
+ *   <li>{@code boolean} and {@code Boolean}, returning {@code true} for at least the following values (case insensitive):
+ *   <ul>
+ *     <li>{@code true}</li>
+ *     <li>{@code yes}</li>
+ *     <li>{@code y}</li>
+ *     <li>{@code on}</li>
+ *     <li>{@code 1}</li>
+ *   </ul>
+ *   <li>{@code byte} and {@code Byte}, accepting (at minimum) all values accepted by the
+ *   {@link Byte#parseByte(String)} method</li>
+ *   <li>{@code short} and {@code Short}, accepting (at minimum) all values accepted by the
+ *   {@link Byte#parseByte(String)} method</li>
+ *   <li>{@code int}, {@code Integer}, and {@code OptionalInt} accepting (at minimum) all values accepted by the
+ *   {@link Integer#parseInt(String)}
+ *   method</li>
+ *   <li>{@code long}, {@code Long}, and {@code OptionalLong} accepting (at minimum) all values accepted by the
+ *   {@link Long#parseLong(String)} method</li>
+ *   <li>{@code float} and {@code Float}, accepting (at minimum) all values accepted by the
+ *   {@link Float#parseFloat(String)} method</li>
+ *   <li>{@code double}, {@code Double}, and {@code OptionalDouble} accepting (at minimum) all values accepted by the
+ *   {@link Double#parseDouble(String)} method</li>
+ *   <li>{@code java.lang.Class} based on the result of {@link java.lang.Class#forName}</li>
+ *   <li>{@code java.lang.String}</li>
  * </ul>
  *
  * <h3 id="discovery">Global converter discovery</h3>
  *
- * Custom global converters may be added to a configuration via the {@link java.util.ServiceLoader} mechanism, and as such can be
- * registered by providing a {@linkplain ClassLoader#getResource(String) resource} named
+ * <p>
+ * Custom global converters may be added to a configuration via the {@link java.util.ServiceLoader} mechanism, and as
+ * such can be registered by providing a {@linkplain ClassLoader#getResource(String) resource} named
  * "{@code META-INF/services/org.eclipse.microprofile.config.spi.Converter}" which contains the fully qualified
  * {@code Converter} implementation class name(s) (one per line) as content.
  * <p>
  * It is also possible to explicitly register a global converter to a {@linkplain ConfigBuilder configuration builder}
- * using the {@link ConfigBuilder#withConverters(Converter[])} and {@link ConfigBuilder#withConverter(Class, int, Converter)}
- * methods.
+ * using the {@link ConfigBuilder#withConverters(Converter[])} and
+ * {@link ConfigBuilder#withConverter(Class, int, Converter)} methods.
  *
  * <h3 id="implicit">Implicit converters</h3>
  *
+ * <p>
  * If no global converter can be found for a given type, the configuration implementation must attempt to derive an
  * <em>implicit converter</em> if any of the following are true (in order):
  *
  * <ul>
- *     <li>the target type has a {@code public static T of(String)} method</li>
- *     <li>the target type has a {@code public static T valueOf(String)} method</li>
- *     <li>the target type has a {@code public static T parse(CharSequence)} method</li>
- *     <li>the target type has a public constructor with a single parameter of type {@code String}</li>
- *     <li>the target type is an array of any type corresponding to either a registered <a href="#global_converters"><em>global</em></a>
- *     converter or a <a href="#built_in_converters"><em>built in</em></a> or <em>implicit</em> converter</li>
+ *   <li>the target type has a {@code public static T of(String)} method</li>
+ *   <li>the target type has a {@code public static T valueOf(String)} method</li>
+ *   <li>the target type has a {@code public static T parse(CharSequence)} method</li>
+ *   <li>the target type has a public constructor with a single parameter of type {@code String}</li>
+ *   <li>the target type is an array of any type corresponding to either a registered
+ *   <a href="#global_converters"><em>global</em></a> converter or a
+ *   <a href="#built_in_converters"><em>built in</em></a> or <em>implicit</em> converter</li>
  * </ul>
  *
  * <h3 id="priority">Converter priority</h3>
  *
- * A converter implementation class can specify a priority by way of the standard {@code javax.annotation.Priority} annotation
- * or by explicitly specifying the priority value to the appropriate
+ * <p>
+ * A converter implementation class can specify a priority by way of the standard {@code javax.annotation.Priority}
+ * annotation or by explicitly specifying the priority value to the appropriate
  * {@linkplain ConfigBuilder#withConverter(Class, int, Converter) builder method}.
+ * <p>
  * If no priority is explicitly assigned, the default priority value of {@code 100} is assumed.
  * <p>
- * If multiple converters are registered for the same type, the one with the highest numerical priority value will be used.
+ * If multiple converters are registered for the same type, the one with the highest numerical priority value will be
+ * used.
  * <p>
- * All <em>built in</em> Converters have a priority value of {@code 1}.
- * <em>Implicit</em> converters are only created when no other converter was found; therefore, they do not have a
- * priority.
+ * All <em>built in</em> Converters have a priority value of {@code 1}. <em>Implicit</em> converters are only created
+ * when no other converter was found; therefore, they do not have a priority.
  *
  * <h3>Array conversion</h3>
  *
+ * <p>
  * A conforming implementation must support the automatic creation of an <em>implicit</em> converter for array types.
- * This converter uses a comma ({@code U+002C ','}) as a delimiter.  To allow a comma to be embedded within individual
- * array element values, it may be escaped using a backslash ({@code U+005C '\'}) character.  Any escaped comma character
- * will be included as a plain comma within the single element (the backslash is discarded by the converter).
+ * This converter uses a comma ({@code U+002C ','}) as a delimiter. To allow a comma to be embedded within individual
+ * array element values, it may be escaped using a backslash ({@code U+005C '\'}) character. Any escaped comma
+ * character will be included as a plain comma within the single element (the backslash is discarded by the converter).
  *
  * @author <a href="mailto:rsmeral@apache.org">Ron Smeral</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
@@ -126,7 +134,6 @@ public interface Converter<T> extends Serializable {
      *
      * @param value the string representation of a property value (must not be {@code null})
      * @return the converted value, or {@code null} if the value is empty
-     *
      * @throws IllegalArgumentException if the value cannot be converted to the specified type
      * @throws NullPointerException if the given value was {@code null}
      */

--- a/api/src/main/java/org/eclipse/microprofile/config/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/spi/package-info.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,14 +15,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 
 /**
  * This package contains classes which are used to implement the configuration API, and to extend the standard
  * configuration functionality in a portable way.
  * <p>
  * Users and frameworks may provide custom {@link org.eclipse.microprofile.config.spi.ConfigSource} and
- * {@link org.eclipse.microprofile.config.spi.Converter} instances.  Configuration instances may be set up and created
+ * {@link org.eclipse.microprofile.config.spi.Converter} instances. Configuration instances may be set up and created
  * using the {@link org.eclipse.microprofile.config.spi.ConfigBuilder} API.
  * <p>
  * The package also contains the class {@link org.eclipse.microprofile.config.spi.ConfigProviderResolver},


### PR DESCRIPTION
There are a lot of changes here, but I didn't modify the content itself.

This work was mostly to make the docs consistent between all sources:

- Removed duplicated empty lines.
- Removed double spaces.
- Wrap at 120 chars.
- Same indentations for li and ol.
- Use paragraphs where required.
- Fixed javadoc warnings.