### PR TITLE
Move ConfigValueBean into it's own class

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigValueBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigValueBean.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.config.tck;
+
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+@Dependent
+public class ConfigValueBean {
+    @Inject
+    @ConfigProperty(name = "my.prop")
+    private ConfigValue configValue;
+
+    @Inject
+    @ConfigProperty(name = "my.prop.default", defaultValue = "default")
+    private ConfigValue configValueDefault;
+
+    ConfigValue getConfigValue() {
+        return configValue;
+    }
+
+    ConfigValue getConfigValueDefault() {
+        return configValueDefault;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigValueTest.java
@@ -20,7 +20,6 @@ package org.eclipse.microprofile.config.tck;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.ConfigValue;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -31,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
-import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
@@ -150,25 +148,6 @@ public class ConfigValueTest extends Arquillian {
         @Override
         public int getOrdinal() {
             return 900;
-        }
-    }
-
-    @Dependent
-    public static class ConfigValueBean {
-        @Inject
-        @ConfigProperty(name = "my.prop")
-        private ConfigValue configValue;
-
-        @Inject
-        @ConfigProperty(name = "my.prop.default", defaultValue = "default")
-        private ConfigValue configValueDefault;
-
-        ConfigValue getConfigValue() {
-            return configValue;
-        }
-
-        ConfigValue getConfigValueDefault() {
-            return configValueDefault;
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: tevans <tevans@uk.ibm.com>

@Emily-Jiang Since Arquillian adds the test class to the archive by default, the nested bean class appears twice and leads to an ambiguous bean error.