### PR TITLE
Avoid duplicate beans in deployments

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPropertyExpressionsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/CDIPropertyExpressionsTest.java
@@ -35,23 +35,17 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 public class CDIPropertyExpressionsTest extends Arquillian {
     @Deployment
     public static Archive<?> deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "CDIPropertyExpressionsTest.jar")
-                .addClasses(PropertyExpressionBean.class)
-                .addAsServiceProvider(ConfigSource.class, PropertyExpressionConfigSource.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
-
         return ShrinkWrap
                 .create(WebArchive.class, "CDIPropertyExpressionsTest.war")
-                .addAsLibrary(testJar);
+                .addClasses(PropertyExpressionBean.class)
+                .addAsServiceProvider(ConfigSource.class, PropertyExpressionConfigSource.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigPropertiesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigPropertiesTest.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -56,11 +55,11 @@ public class ConfigPropertiesTest extends Arquillian {
 
     @Deployment
     public static WebArchive deploy() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "ConfigPropertiesTest.jar")
+        return ShrinkWrap
+                .create(WebArchive.class, "ConfigPropertiesTest.war")
                 .addClasses(ConfigPropertiesTest.class, BeanOne.class, BeanTwo.class, BeanThree.class, BeanFour.class,
                         Location.class)
-                .addAsManifestResource(
+                .addAsResource(
                         new StringAsset(
                                 "customer.name=Bob\n" +
                                         "customer.age=24\n" +
@@ -87,13 +86,8 @@ public class ConfigPropertiesTest extends Arquillian {
                                         "other.name=Holly\n" +
                                         "other.age=20\n" +
                                         "other.nationality=USA\n"),
-                        "microprofile-config.properties")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
-
-        return ShrinkWrap
-                .create(WebArchive.class, "ConfigPropertiesTest.war")
-                .addAsLibrary(testJar);
+                        "META-INF/microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
     @Test
     public void testConfigPropertiesPlainInjection() {

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
@@ -39,7 +39,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -54,18 +53,14 @@ public class ConfigProviderTest extends Arquillian {
 
     @Deployment
     public static WebArchive deploy() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "configProviderTest.jar")
-                .addPackage(AbstractTest.class.getPackage())
-                .addClass(ConfigProviderTest.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
-
-        AbstractTest.addFile(testJar, "META-INF/microprofile-config.properties");
-
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "configProviderTest.war")
-                .addAsLibrary(testJar);
+                .addPackage(AbstractTest.class.getPackage())
+                .addClass(ConfigProviderTest.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        AbstractTest.addFile(war, "META-INF/microprofile-config.properties");
+
         return war;
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigValueTest.java
@@ -35,27 +35,20 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
 public class ConfigValueTest extends Arquillian {
     @Deployment
-    public static Archive deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "ConfigValueTest.jar")
+    public static WebArchive deployment() {
+        return ShrinkWrap
+                .create(WebArchive.class, "ConfigValueTest.war")
                 .addClasses(ConfigValueBean.class)
                 .addAsServiceProvider(ConfigSource.class, ConfigValueConfigSource.class,
                         ConfigValueLowerConfigSource.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
-
-        return ShrinkWrap
-                .create(WebArchive.class, "ConfigValueTest.war")
-                .addAsLibrary(testJar);
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/base/AbstractTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/base/AbstractTest.java
@@ -21,20 +21,20 @@ package org.eclipse.microprofile.config.tck.base;
 
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.container.ResourceContainer;
 
 /**
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  */
 public class AbstractTest extends Arquillian {
 
-    public static void addFile(JavaArchive archive, String originalPath) {
+    public static void addFile(ResourceContainer<?> archive, String originalPath) {
         archive.addAsResource(
                 new UrlAsset(Thread.currentThread().getContextClassLoader().getResource("internal/" + originalPath)),
                 originalPath);
     }
 
-    public static void addFile(JavaArchive archive, String originalFile, String targetFile) {
+    public static void addFile(ResourceContainer<?> archive, String originalFile, String targetFile) {
         archive.addAsResource(new UrlAsset(Thread.currentThread().getContextClassLoader().getResource(originalFile)),
                 targetFile);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/DefaultConfigSourceOrdinalTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/DefaultConfigSourceOrdinalTest.java
@@ -20,6 +20,7 @@
 package org.eclipse.microprofile.config.tck.configsources;
 
 import javax.inject.Inject;
+
 import org.eclipse.microprofile.config.Config;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -44,52 +45,50 @@ public class DefaultConfigSourceOrdinalTest extends Arquillian {
     @Deployment
     public static Archive deployment() {
         JavaArchive testJar = ShrinkWrap
-            .create(JavaArchive.class, "DefaultConfigSourceOrdinalTest.jar")
-            .addClasses(DefaultConfigSourceOrdinalTest.class)
-            .addAsManifestResource(
-                    new StringAsset(
-                        "config_ordinal=200\n" +
-                        "customer_name=Bill\n" +
-                        "customer.hobby=Badminton"
-                        ),
+                .create(JavaArchive.class, "DefaultConfigSourceOrdinalTest.jar")
+                .addClasses(DefaultConfigSourceOrdinalTest.class)
+                .addAsManifestResource(
+                        new StringAsset(
+                                "config_ordinal=200\n" +
+                                        "customer_name=Bill\n" +
+                                        "customer.hobby=Badminton"),
                         "microprofile-config.properties")
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-            .as(JavaArchive.class);
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
 
         WebArchive war = ShrinkWrap
-            .create(WebArchive.class, "DefaultConfigSourceOrdinalTest.war")
-            .addAsLibrary(testJar);
+                .create(WebArchive.class, "DefaultConfigSourceOrdinalTest.war")
+                .addAsLibrary(testJar);
         return war;
     }
 
     @BeforeClass
     public void checkSetup() {
-       //check whether the environment variables were populated by the executor correctly
+        // check whether the environment variables were populated by the executor correctly
 
         if (!"45".equals(System.getenv("config_ordinal"))) {
-         Assert.fail("Before running this test, the environment variable \"config_ordinal\" must be set with the value of 45");
+            Assert.fail(
+                    "Before running this test, the environment variable \"config_ordinal\" must be set with the value of 45");
         }
         if (!"Bob".equals(System.getenv("customer_name"))) {
-         Assert.fail("Before running this test, the environment variable \"customer_name\" must be set with the value of Bob");
+            Assert.fail(
+                    "Before running this test, the environment variable \"customer_name\" must be set with the value of Bob");
         }
         System.setProperty("customer.hobby", "Tennis");
         System.setProperty("config_ordinal", "120");
-        
-        
-        
+
     }
-    
+
     @Test
     public void testOrdinalForEnv() {
         Assert.assertEquals("Bill", config.getValue("customer_name", String.class));
         Assert.assertEquals(200, config.getConfigValue("customer_name").getSourceOrdinal());
     }
-    
+
     @Test
     public void testOrdinalForSystemProps() {
         Assert.assertEquals("Badminton", config.getValue("customer.hobby", String.class));
         Assert.assertEquals(200, config.getConfigValue("customer.hobby").getSourceOrdinal());
     }
-    
-    
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ConfigPropertyFileProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ConfigPropertyFileProfileTest.java
@@ -32,11 +32,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -47,32 +45,28 @@ import org.testng.annotations.Test;
  */
 public class ConfigPropertyFileProfileTest extends Arquillian {
     @Deployment
-    public static Archive deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "ConfigPropertyFileProfileTest.jar")
+    public static WebArchive deployment() {
+
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "ConfigPropertyFileProfileTest.war")
                 .addClasses(ConfigPropertyFileProfileTest.class, ProfilePropertyBean.class)
-                .addAsManifestResource(
+                .addAsResource(
                         new StringAsset(
                                 "mp.config.profile=dev\n" +
                                         "vehicle.name=car\n" +
                                         "vehicle.colour=red"),
-                        "microprofile-config.properties")
-                .addAsManifestResource(new StringAsset(
+                        "META-INF/microprofile-config.properties")
+                .addAsResource(new StringAsset(
                         "vehicle.name=bike\n" +
                                 "vehicle.owner=Bob"),
-                        "microprofile-config-dev.properties")
-                .addAsManifestResource(new StringAsset(
+                        "META-INF/microprofile-config-dev.properties")
+                .addAsResource(new StringAsset(
                         "vehicle.name=bike\n" +
                                 "vehicle.age=5"),
-                        "microprofile-config-prod.properties")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
+                        "META-INF/microprofile-config-prod.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
-        WebArchive war = ShrinkWrap
-                .create(WebArchive.class, "ConfigPropertyFileProfileTest.war")
-                .addAsLibrary(testJar);
         return war;
-
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/DevConfigProfileTest.java
@@ -30,11 +30,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -45,26 +43,21 @@ import org.testng.annotations.Test;
  */
 public class DevConfigProfileTest extends Arquillian {
     @Deployment
-    public static Archive deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "DevConfigProfileTest.jar")
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "DevConfigProfileTest.war")
                 .addClasses(DevConfigProfileTest.class, ProfilePropertyBean.class)
-                .addAsManifestResource(
+                .addAsResource(
                         new StringAsset(
                                 "mp.config.profile=dev\n" +
                                         "%dev.vehicle.name=bike\n" +
                                         "%prod.vehicle.name=bus\n" +
                                         "%test.vehicle.name=van\n" +
                                         "vehicle.name=car"),
-                        "microprofile-config.properties")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
+                        "META-INF/microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
-        WebArchive war = ShrinkWrap
-                .create(WebArchive.class, "DevConfigProfileTest.war")
-                .addAsLibrary(testJar);
         return war;
-
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/InvalidConfigProfileTest.java
@@ -30,11 +30,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -45,24 +43,21 @@ import org.testng.annotations.Test;
  */
 public class InvalidConfigProfileTest extends Arquillian {
     @Deployment
-    public static Archive deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "InvalidConfigProfileTest.jar")
+    public static WebArchive deployment() {
+
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "InvalidConfigProfileTest.war")
                 .addClasses(InvalidConfigProfileTest.class, ProfilePropertyBean.class)
-                .addAsManifestResource(
+                .addAsResource(
                         new StringAsset(
                                 "mp.config.profile=invalid\n" +
                                         "%dev.vehicle.name=bike\n" +
                                         "%prod.vehicle.name=bus\n" +
                                         "%test.vehicle.name=van\n" +
                                         "vehicle.name=car"),
-                        "microprofile-config.properties")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
+                        "META-INF/microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
-        WebArchive war = ShrinkWrap
-                .create(WebArchive.class, "InvalidConfigProfileTest.war")
-                .addAsLibrary(testJar);
         return war;
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ProdProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/ProdProfileTest.java
@@ -30,11 +30,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -45,24 +43,20 @@ import org.testng.annotations.Test;
  */
 public class ProdProfileTest extends Arquillian {
     @Deployment
-    public static Archive deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "ProdProfileTest.jar")
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "ProdProfileTest.war")
                 .addClasses(ProdProfileTest.class, ProfilePropertyBean.class)
-                .addAsManifestResource(
+                .addAsResource(
                         new StringAsset(
                                 "mp.config.profile=prod\n" +
                                         "%dev.vehicle.name=bike\n" +
                                         "%prod.vehicle.name=bus\n" +
                                         "%test.vehicle.name=van\n" +
                                         "vehicle.name=car"),
-                        "microprofile-config.properties")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
+                        "META-INF/microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
-        WebArchive war = ShrinkWrap
-                .create(WebArchive.class, "ProdProfileTest.war")
-                .addAsLibrary(testJar);
         return war;
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestConfigProfileTest.java
@@ -30,11 +30,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -45,24 +43,19 @@ import org.testng.annotations.Test;
  */
 public class TestConfigProfileTest extends Arquillian {
     @Deployment
-    public static Archive deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "TestConfigProfileTest.jar")
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "TestConfigProfileTest.war")
                 .addClasses(TestConfigProfileTest.class, ProfilePropertyBean.class)
-                .addAsManifestResource(
+                .addAsResource(
                         new StringAsset(
                                 "mp.config.profile=test\n" +
                                         "%dev.vehicle.name=bike\n" +
                                         "%prod.vehicle.name=bus\n" +
                                         "%test.vehicle.name=van\n" +
                                         "vehicle.name=car"),
-                        "microprofile-config.properties")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
-
-        WebArchive war = ShrinkWrap
-                .create(WebArchive.class, "TestConfigProfileTest.war")
-                .addAsLibrary(testJar);
+                        "META-INF/microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestCustomConfigProfile.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/TestCustomConfigProfile.java
@@ -32,11 +32,9 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.tck.configsources.CustomConfigProfileConfigSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -47,26 +45,21 @@ import org.testng.annotations.Test;
  */
 public class TestCustomConfigProfile extends Arquillian {
     @Deployment
-    public static Archive deployment() {
-        JavaArchive testJar = ShrinkWrap
-                .create(JavaArchive.class, "TestConfigProfileTest.jar")
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "TestConfigProfileTest.war")
                 .addClasses(TestCustomConfigProfile.class, ProfilePropertyBean.class,
                         CustomConfigProfileConfigSource.class)
                 .addAsServiceProvider(ConfigSource.class, CustomConfigProfileConfigSource.class)
-                .addAsManifestResource(
+                .addAsResource(
                         new StringAsset(
                                 "mp.config.profile=prod\n" +
                                         "%dev.vehicle.name=bus\n" +
                                         "%prod.vehicle.name=bike\n" +
                                         "%test.vehicle.name=coach\n" +
                                         "vehicle.name=car"),
-                        "microprofile-config.properties")
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
-
-        WebArchive war = ShrinkWrap
-                .create(WebArchive.class, "TestConfigProfileTest.war")
-                .addAsLibrary(testJar);
+                        "META-INF/microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }
 


### PR DESCRIPTION
Where a test uses beans which are inner classes of the test class,
use a single .war deployment rather than a jar within a war.

This prevents the test beans from being included twice (once in the .jar
and again in the .war).

Fixes #613 