### PR TITLE
Move bean out of test class for invalid app test

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/ConfigPropertiesBeanMissingProperty.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/ConfigPropertiesBeanMissingProperty.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.config.tck.broken;
+
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+
+@ConfigProperties(prefix = "customer")
+public class ConfigPropertiesBeanMissingProperty {
+    private String name;
+    public int age;
+    public String nationality; // no corresponding config property customer.nationality exists
+
+    /**
+     * @return String return the name
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/ConfigPropertiesMissingPropertyInjectionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/broken/ConfigPropertiesMissingPropertyInjectionTest.java
@@ -20,9 +20,7 @@
 package org.eclipse.microprofile.config.tck.broken;
 
 import javax.enterprise.inject.spi.DeploymentException;
-import javax.inject.Inject;
 
-import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.testng.Arquillian;
@@ -40,14 +38,12 @@ import org.testng.annotations.Test;
  */
 public class ConfigPropertiesMissingPropertyInjectionTest extends Arquillian {
 
-    private @Inject BeanOne customerBeanOne;
-
     @Deployment
     @ShouldThrowException(DeploymentException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ConfigPropertiesTest.jar")
-                .addClasses(ConfigPropertiesMissingPropertyInjectionTest.class, BeanOne.class)
+                .addClasses(ConfigPropertiesBeanMissingProperty.class)
                 .addAsManifestResource(
                         new StringAsset(
                                 "customer.name=Bob\n" +
@@ -63,19 +59,5 @@ public class ConfigPropertiesMissingPropertyInjectionTest extends Arquillian {
 
     @Test
     public void test() {
-    }
-
-    @ConfigProperties(prefix = "customer")
-    public static class BeanOne {
-        private String name;
-        public int age;
-        public String nationality; // no corresponding config property customer.nationality exists
-
-        /**
-         * @return String return the name
-         */
-        public String getName() {
-            return name;
-        }
     }
 }


### PR DESCRIPTION
When a deployment uses `ShouldThrowException`, arquillian does not include
the arquillian support classes in the deployed app, including the
`Arquillian` class which the test extends.

In this case, if arquillian is not on the class path on the server, this
test will fail because the test bean cannot be loaded because it depends
on the `Arquillian` class and so doesn't cause the expected deployment
exception.

Fixes #617