### PR TITLE
Move bean out of test class in null injection test

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/convertToNull/ConvertedNullValueBrokenInjectionBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/convertToNull/ConvertedNullValueBrokenInjectionBean.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.config.tck.converters.convertToNull;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.tck.converters.Pizza;
+
+@ApplicationScoped
+public class ConvertedNullValueBrokenInjectionBean {
+
+    private @Inject @ConfigProperty(name = "partial.pizza", defaultValue = "medium:chicken") Pizza myPizza;
+
+    public Pizza getPizza() {
+        return myPizza;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/convertToNull/ConvertedNullValueBrokenInjectionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/converters/convertToNull/ConvertedNullValueBrokenInjectionTest.java
@@ -19,12 +19,10 @@
  */
 package org.eclipse.microprofile.config.tck.converters.convertToNull;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.DeploymentException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.Converter;
 import org.eclipse.microprofile.config.tck.converters.Pizza;
 import org.eclipse.microprofile.config.tck.converters.PizzaConverter;
@@ -44,14 +42,14 @@ import org.testng.annotations.Test;
  */
 public class ConvertedNullValueBrokenInjectionTest extends Arquillian {
     private @Inject Config config;
-    private @Inject MyBean myBean;
+    private @Inject ConvertedNullValueBrokenInjectionBean myBean;
 
     @Deployment
     @ShouldThrowException(DeploymentException.class)
     public static Archive deployment() {
         return ShrinkWrap.create(WebArchive.class, "ConvertedNullValueBrokenInjectionTest.war")
                 .addClasses(ConvertedNullValueBrokenInjectionTest.class, Pizza.class, PizzaConverter.class,
-                        MyBean.class)
+                        ConvertedNullValueBrokenInjectionBean.class)
                 .addAsResource(
                         new StringAsset(
                                 "partial.pizza=cheese"),
@@ -63,16 +61,6 @@ public class ConvertedNullValueBrokenInjectionTest extends Arquillian {
 
     @Test
     public void test() {
-    }
-
-    @ApplicationScoped
-    public static class MyBean {
-
-        private @Inject @ConfigProperty(name = "partial.pizza", defaultValue = "medium:chicken") Pizza myPizza;
-
-        public Pizza getPizza() {
-            return myPizza;
-        }
     }
 
 }


### PR DESCRIPTION
When a deployment uses ShouldThrowException, arquillian does not include
the arquillian support classes in the deployed app, including the
Arquillian class which the test extends.

In this case, if arquillian is not on the class path on the server, this
test will fail because the test bean cannot be loaded because it depends
on the Arquillian class and so doesn't cause the expected deployment
exception.

Fixes #617 (again)