### PR TITLE
Spec doesn't mention String as a built-in converter

### DIFF
--- a/spec/src/main/asciidoc/converters.asciidoc
+++ b/spec/src/main/asciidoc/converters.asciidoc
@@ -41,6 +41,7 @@ The following ``Converter``s are provided by MicroProfile Config by default:
 * `double`, `java.lang.Double`, and `java.util.OptionalDouble`; a dot '.' is used to separate the fractional digits
 * `char` and `java.lang.Character`
 * `java.lang.Class` based on the result of `Class.forName`
+* `java.lang.String`
 
 All built-in ``Converter``s have the `@Priority` of `1`.
 


### PR DESCRIPTION
Spec doesn't mention String as a built-in converter ... the Converter JavaDoc does
https://github.com/eclipse/microprofile-config/blob/4bda7c776e00a3baf41af728215900e02485de2c/api/src/main/java/org/eclipse/microprofile/config/spi/Converter.java#L70