### PR TITLE
deps: Update osgi.annotation dependency to 8.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
         <dependencies>
             <!-- TODO - Investigate BND Dependencies-->
             <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>8.1.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>biz.aQute.bnd.annotation</artifactId>
                 <version>5.3.0</version>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>


### PR DESCRIPTION
Version 8.1.0 removes the use of enum types in the annotations which
avoids compiler warnings for downstream users of the api jar.

We also include osgi.annotation in the tck project to make the
annotation classes available to javadoc to avoid warnings.
