### PR TITLE
deps: Update osgi.annotation dependency to 8.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <links>https://osgi.org/javadoc/osgi.annotation/7.0.0/</links>
+        <links>https://docs.osgi.org/javadoc/osgi.annotation/8.1.0</links>
 
         <bnd.version>5.1.0</bnd.version>
         <checkstyle.version>2.17</checkstyle.version>
@@ -142,7 +142,7 @@
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.annotation</artifactId>
-                <version>7.0.0</version>
+                <version>8.1.0</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>
@@ -229,7 +229,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.3.1</version>
+                    <configuration>
+                        <additionalJOptions>
+                            <additionalJOption>-J-Dhttp.agent=maven-javadoc-plugin</additionalJOption>
+                        </additionalJOptions>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Version 8.1.0 removes the use of enum types in the annotations which
avoids compiler warnings for downstream users of the api jar.

We also configure the maven-javadoc-plugin to be able to access
the package-list file for the osgi.annotation javadoc. The default
Java user agent value causes the server to deny the request.
