### PR TITLE
Align BND dependencies to avoid compiler warnings in 3.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,15 +81,21 @@
         <dependencies>
             <!-- TODO - Investigate BND Dependencies-->
             <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.annotation</artifactId>
+                <version>8.1.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>biz.aQute.bnd.annotation</artifactId>
-                <version>5.3.0</version>
+                <version>6.2.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.service.cdi</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.1</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
The version **8.1.0** of `osgi.annotation` removes the use of enum types in the annotations which avoids compiler warnings for downstream users of `microprofile-config-api` jar.

This backports #732 to `3.0.x` branch, which was merged into `master` after the `3.0.x` was branched.

See: #716
See: https://github.com/eclipse/microprofile-config/pull/732#issuecomment-1482128111
See: https://github.com/quarkusio/quarkus/issues/32332