### PR TITLE
ci: use actions/setup-java temurin distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-java@v3
         name: set up jdk ${{matrix.java}}
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: ${{matrix.java}}
 
       - name: build with maven


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates

See : https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
