### PR TITLE
[Fix 777] Add javax.inject.Qualifier to allow integration with Guice.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -39,6 +39,11 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cdi</artifactId>
         </dependency>
+        <!-- https://github.com/eclipse/microprofile-config/issues/777 -->
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
+++ b/api/src/main/java/org/eclipse/microprofile/config/inject/ConfigProperty.java
@@ -110,6 +110,7 @@ import jakarta.inject.Qualifier;
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author <a href="mailto:struberg@apache.org">Mark Struberg</a>
  */
+@javax.inject.Qualifier
 @Qualifier
 @Retention(RUNTIME)
 @Target({METHOD, FIELD, PARAMETER, TYPE})

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -103,6 +104,14 @@
                 <artifactId>microprofile-config-api</artifactId>
                 <version>${project.version}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <!-- https://github.com/eclipse/microprofile-config/issues/777 -->
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
+                <optional>true</optional>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Add `@javax.inject.Qualifier` to `@ConfigProperty` in order to allow integration with Guice; make the dependency optional so that the dependency is not transitive.