### PR TITLE
Switch expected and actual values to match TestNG assertEquals

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigPropertiesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigPropertiesTest.java
@@ -87,63 +87,63 @@ public class ConfigPropertiesTest extends Arquillian {
     @Test
     public void testConfigPropertiesPlainInjection() {
         BeanOne customerBeanOne = bean.getCustomerBeanOne();
-        Assert.assertEquals("Bob", customerBeanOne.getName());
-        Assert.assertEquals(24, customerBeanOne.age);
-        Assert.assertEquals("Developer", customerBeanOne.job);
-        Assert.assertEquals(new String[]{"Badminton", "Tennis"}, customerBeanOne.hobbies);
-        Assert.assertEquals(new Location("2 Hook Road, Winchester, Hampshire, SO21 2JN, UK"), customerBeanOne.location);
+        Assert.assertEquals(customerBeanOne.getName(), "Bob");
+        Assert.assertEquals(customerBeanOne.age, 24);
+        Assert.assertEquals(customerBeanOne.job, "Developer");
+        Assert.assertEquals(customerBeanOne.hobbies, new String[]{"Badminton", "Tennis"});
+        Assert.assertEquals(customerBeanOne.location, new Location("2 Hook Road, Winchester, Hampshire, SO21 2JN, UK"));
     }
 
     @Test
     public void testConfigPropertiesWithPrefix() {
         BeanOne clientBeanOne = bean.getClientBeanOne();
-        Assert.assertEquals("Rob", clientBeanOne.getName());
-        Assert.assertEquals(25, clientBeanOne.age);
-        Assert.assertEquals("Engineer", clientBeanOne.job);
-        Assert.assertEquals(new String[]{"Football", "Tennis"}, clientBeanOne.hobbies);
-        Assert.assertEquals(new Location("22 Hook Road, Winchester, Hampshire, SO21 2JN, UK"), clientBeanOne.location);
+        Assert.assertEquals(clientBeanOne.getName(), "Rob");
+        Assert.assertEquals(clientBeanOne.age, 25);
+        Assert.assertEquals(clientBeanOne.job, "Engineer");
+        Assert.assertEquals(clientBeanOne.hobbies, new String[]{"Football", "Tennis"});
+        Assert.assertEquals(clientBeanOne.location, new Location("22 Hook Road, Winchester, Hampshire, SO21 2JN, UK"));
 
         // programmatic lookup of the beans
         BeanOne bo = CDI.current().select(BeanOne.class, ConfigProperties.Literal.of("client")).get();
-        Assert.assertEquals("Rob", bo.getName());
-        Assert.assertEquals(25, bo.age);
-        Assert.assertEquals("Engineer", bo.job);
-        Assert.assertEquals(new String[]{"Football", "Tennis"}, bo.hobbies);
-        Assert.assertEquals(new Location("22 Hook Road, Winchester, Hampshire, SO21 2JN, UK"), bo.location);
+        Assert.assertEquals(bo.getName(), "Rob");
+        Assert.assertEquals(bo.age, 25);
+        Assert.assertEquals(bo.job, "Engineer");
+        Assert.assertEquals(bo.hobbies, new String[]{"Football", "Tennis"});
+        Assert.assertEquals(bo.location, new Location("22 Hook Road, Winchester, Hampshire, SO21 2JN, UK"));
     }
 
     @Test
     public void testConfigPropertiesWithoutPrefix() {
         BeanOne beanOne = bean.getBeanOne();
-        Assert.assertEquals("Harry", beanOne.getName());
-        Assert.assertEquals(21, beanOne.age);
-        Assert.assertEquals("Plumber", beanOne.job);
-        Assert.assertEquals(new String[]{"Volleyball"}, beanOne.hobbies);
-        Assert.assertEquals(new Location("222 Hook Road, Winchester, Hampshire, SO21 2JN, UK"), beanOne.location);
+        Assert.assertEquals(beanOne.getName(), "Harry");
+        Assert.assertEquals(beanOne.age, 21);
+        Assert.assertEquals(beanOne.job, "Plumber");
+        Assert.assertEquals(beanOne.hobbies, new String[]{"Volleyball"});
+        Assert.assertEquals(beanOne.location, new Location("222 Hook Road, Winchester, Hampshire, SO21 2JN, UK"));
 
         // programmatic lookup of the beans
         BeanOne bo = CDI.current().select(BeanOne.class, ConfigProperties.Literal.of("")).get();
-        Assert.assertEquals("Harry", bo.getName());
-        Assert.assertEquals(21, bo.age);
-        Assert.assertEquals("Plumber", bo.job);
-        Assert.assertEquals(new String[]{"Volleyball"}, bo.hobbies);
-        Assert.assertEquals(new Location("222 Hook Road, Winchester, Hampshire, SO21 2JN, UK"), bo.location);
+        Assert.assertEquals(bo.getName(), "Harry");
+        Assert.assertEquals(bo.age, 21);
+        Assert.assertEquals(bo.job, "Plumber");
+        Assert.assertEquals(bo.hobbies, new String[]{"Volleyball"});
+        Assert.assertEquals(bo.location, new Location("222 Hook Road, Winchester, Hampshire, SO21 2JN, UK"));
     }
 
     @Test
     public void testConfigPropertiesNoPrefixOnBean() {
         BeanTwo beanTwo = bean.getBeanTwo();
-        Assert.assertEquals("localhost", beanTwo.getHost());
-        Assert.assertEquals(9080, beanTwo.port);
-        Assert.assertEquals("woof", beanTwo.endpoint);
+        Assert.assertEquals(beanTwo.getHost(), "localhost");
+        Assert.assertEquals(beanTwo.port, 9080);
+        Assert.assertEquals(beanTwo.endpoint, "woof");
     }
 
     @Test
     public void testConfigPropertiesNoPrefixOnBeanThenSupplyPrefix() {
         BeanTwo myBeanTwo = bean.getMyBeanTwo();
-        Assert.assertEquals("myhost", myBeanTwo.getHost());
-        Assert.assertEquals(9081, myBeanTwo.port);
-        Assert.assertEquals("poof", myBeanTwo.endpoint);
+        Assert.assertEquals(myBeanTwo.getHost(), "myhost");
+        Assert.assertEquals(myBeanTwo.port, 9081);
+        Assert.assertEquals(myBeanTwo.endpoint, "poof");
     }
 
     @Test
@@ -152,15 +152,15 @@ public class ConfigPropertiesTest extends Arquillian {
         // as the bean class has no ConfigProperties annotation.
         BeanThree beanThree = bean.getBeanThree();
         Assert.assertNull(beanThree.name);
-        Assert.assertEquals(0, beanThree.age);
+        Assert.assertEquals(beanThree.age, 0);
         Assert.assertNull(beanThree.getNationality());
     }
 
     @Test
     public void testConfigPropertiesDefaultOnBean() {
         BeanFour myBeanFour = bean.getMyBeanFour();
-        Assert.assertEquals("mycloud.org", myBeanFour.getHost());
-        Assert.assertEquals(9080, myBeanFour.port);
+        Assert.assertEquals(myBeanFour.getHost(), "mycloud.org");
+        Assert.assertEquals(myBeanFour.port, 9080);
         Assert.assertFalse(myBeanFour.location.isPresent());
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/ConfigProviderTest.java
@@ -85,8 +85,8 @@ public class ConfigProviderTest extends Arquillian {
     public void testEnvironmentConfigSource() {
         String value = System.getenv().get("MP_TCK_ENV_DUMMY");
         Assert.assertNotNull(value);
-        Assert.assertEquals("dummy", value);
-        Assert.assertEquals(value, config.getValue("mp.tck.env.dummy", String.class));
+        Assert.assertEquals(value, "dummy");
+        Assert.assertEquals(config.getValue("mp.tck.env.dummy", String.class), "dummy");
     }
 
     @Test
@@ -94,8 +94,8 @@ public class ConfigProviderTest extends Arquillian {
         Assert.assertNotNull(config.getValue("java.version", String.class));
         String value = System.getProperties().getProperty("mp.tck.prop.dummy");
         Assert.assertNotNull(value);
-        Assert.assertEquals("dummy", value);
-        Assert.assertEquals(value, config.getValue("mp.tck.prop.dummy", String.class));
+        Assert.assertEquals(value, "dummy");
+        Assert.assertEquals(config.getValue("mp.tck.prop.dummy", String.class), "dummy");
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/PropertyExpressionsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/PropertyExpressionsTest.java
@@ -75,49 +75,49 @@ public class PropertyExpressionsTest extends Arquillian {
     public void simpleExpression() {
         Config config = buildConfig("my.prop", "1234", "expression", "${my.prop}");
 
-        assertEquals("1234", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "1234");
     }
 
     @Test
     public void multipleExpressions() {
         Config config = buildConfig("my.prop", "1234", "expression", "${my.prop}${my.prop}");
 
-        assertEquals("12341234", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "12341234");
     }
 
     @Test
     public void composedExpressions() {
         Config config = buildConfig("my.prop", "1234", "expression", "${${compose}}", "compose", "my.prop");
 
-        assertEquals("1234", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "1234");
     }
 
     @Test
     public void defaultExpression() {
         Config config = buildConfig("expression", "${my.prop:1234}");
 
-        assertEquals("1234", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "1234");
     }
 
     @Test
     public void defaultExpressionEmpty() {
         Config config = buildConfig("expression", "12${my.prop:}34");
 
-        assertEquals("1234", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "1234");
     }
 
     @Test
     public void defaultExpressionComposed() {
         Config config = buildConfig("expression", "${my.prop:${compose}}", "compose", "1234");
 
-        assertEquals("1234", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "1234");
     }
 
     @Test
     public void defaultExpressionComposedEmpty() {
         Config config = buildConfig("expression", "${my.prop:${compose:}}", "my.prop", "1234");
 
-        assertEquals("1234", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "1234");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class PropertyExpressionsTest extends Arquillian {
     void noExpressionButOptional() {
         Config config = buildConfig("expression", "${my.prop}");
 
-        assertEquals(Optional.empty(), config.getOptionalValue("expression", String.class));
+        assertEquals(config.getOptionalValue("expression", String.class), Optional.empty());
     }
 
     @Test
@@ -157,7 +157,7 @@ public class PropertyExpressionsTest extends Arquillian {
     void noExpressionComposedButOptional() {
         Config config = buildConfig("expression", "${my.prop${compose}}");
 
-        assertEquals(Optional.empty(), config.getOptionalValue("expression", String.class));
+        assertEquals(config.getOptionalValue("expression", String.class), Optional.empty());
     }
 
     @Test
@@ -177,10 +177,10 @@ public class PropertyExpressionsTest extends Arquillian {
         Config config = buildConfig("my.prop", "1234", "my.prop.two", "${my.prop}", "my.prop.three",
                 "${my.prop.two}", "my.prop.four", "${my.prop.three}");
 
-        assertEquals("1234", config.getValue("my.prop", String.class));
-        assertEquals("1234", config.getValue("my.prop.two", String.class));
-        assertEquals("1234", config.getValue("my.prop.three", String.class));
-        assertEquals("1234", config.getValue("my.prop.four", String.class));
+        assertEquals(config.getValue("my.prop", String.class), "1234");
+        assertEquals(config.getValue("my.prop.two", String.class), "1234");
+        assertEquals(config.getValue("my.prop.three", String.class), "1234");
+        assertEquals(config.getValue("my.prop.four", String.class), "1234");
     }
 
     @Test
@@ -195,12 +195,12 @@ public class PropertyExpressionsTest extends Arquillian {
         Config config =
                 buildConfig("my.prop", "1234", "expression", "${my.prop}", PROPERTY_EXPRESSIONS_ENABLED, "false");
 
-        assertEquals("${my.prop}", config.getValue("expression", String.class));
+        assertEquals(config.getValue("expression", String.class), "${my.prop}");
     }
 
     @Test
     public void escape() {
-        assertEquals("${my.prop}", buildConfig("expression", "\\${my.prop}").getValue("expression", String.class));
+        assertEquals(buildConfig("expression", "\\${my.prop}").getValue("expression", String.class), "${my.prop}");
     }
 
     @Test
@@ -208,14 +208,14 @@ public class PropertyExpressionsTest extends Arquillian {
         Config config = buildConfig("list", "cat,dog,${mouse},sea\\,turtle", "mouse", "mouse");
 
         final List<String> list = config.getValues("list", String.class);
-        assertEquals(4, list.size());
+        assertEquals(list.size(), 4);
         assertEquals(list, Stream.of("cat", "dog", "mouse", "sea,turtle").collect(toList()));
     }
 
     @Test
     void escapeBraces() {
         Config config = buildConfig("my.prop", "${value:111{111}");
-        assertEquals("111{111", config.getValue("my.prop", String.class));
+        assertEquals(config.getValue("my.prop", String.class), "111{111");
     }
 
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/DefaultConfigSourceOrdinalTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/configsources/DefaultConfigSourceOrdinalTest.java
@@ -86,14 +86,14 @@ public class DefaultConfigSourceOrdinalTest extends Arquillian {
 
     @Test
     public void testOrdinalForEnv() {
-        Assert.assertEquals("Bill", config.getValue("customer_name", String.class));
-        Assert.assertEquals(200, config.getConfigValue("customer_name").getSourceOrdinal());
+        Assert.assertEquals(config.getValue("customer_name", String.class), "Bill");
+        Assert.assertEquals(config.getConfigValue("customer_name").getSourceOrdinal(), 200);
     }
 
     @Test
     public void testOrdinalForSystemProps() {
-        Assert.assertEquals("Badminton", config.getValue("customer.hobby", String.class));
-        Assert.assertEquals(200, config.getConfigValue("customer.hobby").getSourceOrdinal());
+        Assert.assertEquals(config.getValue("customer.hobby", String.class), "Badminton");
+        Assert.assertEquals(config.getConfigValue("customer.hobby").getSourceOrdinal(), 200);
     }
 
 }


### PR DESCRIPTION
fixes https://github.com/eclipse/microprofile-config/issues/779

In many cases, when using `Assert.assertEquals`, the expected value argument was first rather than second. While this is correct when using JUnit Assertions, MP Config uses TestNG where the actual value comes first and the expected value is second.

This should make no functional difference to the tests but it will mean that the messages are correct should the test fail.