### PR TITLE
Clarify how source ordinal applies with an active profile

### DIFF
--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -45,7 +45,9 @@ If the property `mp.config.profile` is specified in multiple config sources, the
 The configuration property that utilizes the Config Profile is called a "profile-specific" property. A "profile-specific" property name consists of the following sequence: `% <profile name>.<original property name>`.
 
 Conforming implementations are required to search all configuration sources that provide either the property name or the "profile-specific" property name.
-If the configuration source provides the "profile-specific" name, the value of the "profile-specific" property will be returned. If it doesn't contain the "profile-specific" name, the value of the plain property will be returned.
+If the configuration source provides the "profile-specific" name, the value of the "profile-specific" property will be returned.
+If it doesn't contain the "profile-specific" name, the value of the plain property will be returned.
+Thus, the "profile-specific" concept only influences which value is to be surfaced per config source.
 
 For instance, a config source (ordinal 100) can be specified as follows.
 
@@ -76,8 +78,7 @@ The properties `%live.vehicle.name` and `%testing.vehicle.name` are inactive con
 If `mp.config.profile` is set to `live`, the property `%live.vehicle.name` is the active property. The `vehicleName` will be `train`. Similarly, `bike` will be the value of `vehicleName`, if the profile is `testing`.
 If no profile is active, `lorry` will be the value of `vehicleName`.
 
-When another configuration source provides the same property, the final resulting value of the lookup depends on the ordinal (priority) of all providing sources.
-
+As explained above, the override scope is per configure source.
 For instance, an additional source (ordinal 300) may be specified as follows:
 
 [source, text]

--- a/spec/src/main/asciidoc/configprofile.asciidoc
+++ b/spec/src/main/asciidoc/configprofile.asciidoc
@@ -44,11 +44,10 @@ If the property `mp.config.profile` is specified in multiple config sources, the
 ==== On Property level
 The configuration property that utilizes the Config Profile is called a "profile-specific" property. A "profile-specific" property name consists of the following sequence: `% <profile name>.<original property name>`.
 
-Conforming implementations are required to search for a configuration source with the highest ordinal (priority) that provides either the property name or the "profile-specific" property name.
+Conforming implementations are required to search all configuration sources that provide either the property name or the "profile-specific" property name.
 If the configuration source provides the "profile-specific" name, the value of the "profile-specific" property will be returned. If it doesn't contain the "profile-specific" name, the value of the plain property will be returned.
 
-
-For instance, a config source can be specified as follows.
+For instance, a config source (ordinal 100) can be specified as follows.
 
 [source, text]
 ----
@@ -75,6 +74,18 @@ In more details, if `mp.config.profile` is set to `dev`, the property `%dev.vehi
 The properties `%live.vehicle.name` and `%testing.vehicle.name` are inactive config properties and don't override the property `vehicle.name`.
 
 If `mp.config.profile` is set to `live`, the property `%live.vehicle.name` is the active property. The `vehicleName` will be `train`. Similarly, `bike` will be the value of `vehicleName`, if the profile is `testing`.
+If no profile is active, `lorry` will be the value of `vehicleName`.
+
+When another configuration source provides the same property, the final resulting value of the lookup depends on the ordinal (priority) of all providing sources.
+
+For instance, an additional source (ordinal 300) may be specified as follows:
+
+[source, text]
+----
+vehicle.name=helicopter
+----
+
+The value of `vehicleName` will be `helicopter` no matter which profile might be active, as the higher ordinal (300 versus 100) makes the later source win.
 
 ==== On Config Source level
 

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/OverrideConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/OverrideConfigProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * Test cases for Config profile
  *
- * @author Emily Jiang
+ * @author Oliver Bertuch
  */
 public class OverrideConfigProfileTest extends Arquillian {
     @Deployment

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/OverrideConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/OverrideConfigProfileTest.java
@@ -49,9 +49,9 @@ public class OverrideConfigProfileTest extends Arquillian {
                 .addAsResource(
                         new StringAsset(
                                 "mp.config.profile=dev\n" +
-                                "%dev." + PROPERTY + "=foo\n" +
-                                PROPERTY + "=bar\n"),
-                    "META-INF/microprofile-config.properties")
+                                        "%dev." + PROPERTY + "=foo\n" +
+                                        PROPERTY + "=bar\n"),
+                        "META-INF/microprofile-config.properties")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return war;
@@ -61,9 +61,9 @@ public class OverrideConfigProfileTest extends Arquillian {
     private static final String EXPECTED = "dummy";
 
     /**
-     * This test relies on the system property "mp.tck.prop.dummy" being set to "dummy" as described in the TCK
-     * README as a requirement for runners. System properties are per the TCK requirements at ordinal 120, so shall
-     * override the given properties in the microprofile-config.properties file (ordinal 100) included in the WAR above.
+     * This test relies on the system property "mp.tck.prop.dummy" being set to "dummy" as described in the TCK README
+     * as a requirement for runners. System properties are per the TCK requirements at ordinal 120, so shall override
+     * the given properties in the microprofile-config.properties file (ordinal 100) included in the WAR above.
      */
     @Test
     public void testConfigProfileWithDevAndOverride() {

--- a/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/OverrideConfigProfileTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/config/tck/profile/OverrideConfigProfileTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.config.tck.profile;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Test cases for Config profile
+ *
+ * @author Emily Jiang
+ */
+public class OverrideConfigProfileTest extends Arquillian {
+    @Deployment
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap
+                .create(WebArchive.class, "OverrideConfigProfileTest.war")
+                .addClasses(OverrideConfigProfileTest.class, ProfilePropertyBean.class)
+                .addAsResource(
+                        new StringAsset(
+                                "mp.config.profile=dev\n" +
+                                "%dev." + PROPERTY + "=foo\n" +
+                                PROPERTY + "=bar\n"),
+                    "META-INF/microprofile-config.properties")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        return war;
+    }
+
+    private static final String PROPERTY = "mp.tck.prop.dummy";
+    private static final String EXPECTED = "dummy";
+
+    /**
+     * This test relies on the system property "mp.tck.prop.dummy" being set to "dummy" as described in the TCK
+     * README as a requirement for runners. System properties are per the TCK requirements at ordinal 120, so shall
+     * override the given properties in the microprofile-config.properties file (ordinal 100) included in the WAR above.
+     */
+    @Test
+    public void testConfigProfileWithDevAndOverride() {
+        assertThat(System.getProperty(PROPERTY), is(equalTo(EXPECTED)));
+
+        ProfilePropertyBean bean = CDI.current().select(ProfilePropertyBean.class).get();
+        assertThat(bean.getConfigProperty(), is(equalTo(EXPECTED)));
+
+        assertThat(ConfigProvider.getConfig().getValue(PROPERTY, String.class), is(equalTo(EXPECTED)));
+    }
+
+    @Dependent
+    public static class ProfilePropertyBean {
+        @Inject
+        @ConfigProperty(name = PROPERTY)
+        private String stringProperty;
+        public String getConfigProperty() {
+            return stringProperty;
+        }
+    }
+}


### PR DESCRIPTION
Closes #781 

This pull request tries to rephrase parts of the profile on property level spec to clarify how ordinal of sources and the profiled vs. unprofiled values work together.