### PR TITLE
Remove section number from release notes

### DIFF
--- a/spec/src/main/asciidoc/microprofile-config-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-config-spec.asciidoc
@@ -53,4 +53,5 @@ include::configprofile.asciidoc[]
 
 include::property-expressions.asciidoc[]
 
+:sectnums!:
 include::release_notes.asciidoc[]


### PR DESCRIPTION
The section number on the Release Notes brings confusion with release version number