### PR TITLE
Update CI jobs to 17 and 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11,17]
+        java: [17,21]
     name: build with jdk ${{matrix.java}}
 
     steps:


### PR DESCRIPTION
Required by https://github.com/microprofile/microprofile-config/pull/812. Still built to target Java 8, but plugins require 17.